### PR TITLE
add more validations for format and multipleOf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,10 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/README.md
+++ b/README.md
@@ -54,10 +54,48 @@ Following validations are incorporated into models:
 - minimum length: must be a string value of length greater than or equal to a specified value
 - maximum item count: must be a list value with number of items less than or equal to a specified value
 - minimum item count: must be a list value with number of items greater than or equal to a specified value
+- unique items: items must be unique
+- maximum properties count: number of properties must be less than or equal to a specified value
+- minimum properties count: number of properties must be greater than or equal to a specified value
 - pattern: must match the specified regex pattern
+- format: must match the specified format specifier (see subsection below for details)
 - enum: value must be from a list of allowed values
+- multiple of: must be a multiple of a specified value
 
 Validations are imposed in the constructor and `setproperty!` methods of models.
+
+#### Validations for format specifiers
+
+String, number and integer data types can have an optional format modifier that serves as a hint at the contents and format of the string. Validations for the following OpenAPI defined formats are built in:
+
+| Data Type | Format    | Description |
+|-----------|-----------|-------------|
+| number    | float     | Floating-point numbers. |
+| number    | double    | Floating-point numbers with double precision. |
+| integer   | int32     | Signed 32-bit integers (commonly used integer type). |
+| integer   | int64     | Signed 64-bit integers (long type). |
+| string    | date      | full-date notation as defined by RFC 3339, section 5.6, for example, 2017-07-21 |
+| string    | date-time | the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z |
+| string    | byte      | base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw== |
+
+Validations for custom formats can be plugged in by overloading the `OpenAPI.val_format` method.
+
+E.g.:
+
+```julia
+# add a new validation named `custom` for the number type
+function OpenAPI.val_format(val::AbstractFloat, ::Val{:custom})
+    return true # do some validations and return result
+end
+# add a new validation named `custom` for the integer type
+function OpenAPI.val_format(val::Integer, ::Val{:custom})
+    return true # do some validations and return result
+end
+# add a new validation named `custom` for the string type
+function OpenAPI.val_format(val::AbstractString, ::Val{:custom})
+    return true # do some validations and return result
+end
+```
 
 ### Client APIs
 

--- a/src/OpenAPI.jl
+++ b/src/OpenAPI.jl
@@ -1,6 +1,6 @@
 module OpenAPI
 
-using HTTP, JSON, URIs, Dates, TimeZones
+using HTTP, JSON, URIs, Dates, TimeZones, Base64
 
 import Base: getindex, keys, length, iterate
 import JSON: lower

--- a/src/json.jl
+++ b/src/json.jl
@@ -61,6 +61,9 @@ function from_json(o::T, name::Symbol, v) where {T <: APIModel}
         setfield!(o, name, str2datetime(v))
     elseif Date <: ftype
         setfield!(o, name, str2date(v))
+    elseif String <: ftype && isa(v, Real)
+        # string numbers can have format specifiers that allow numbers, ensure they are converted to strings
+        setfield!(o, name, string(v))
     else
         setfield!(o, name, convert(ftype, v))
     end
@@ -83,6 +86,10 @@ function from_json(o::T, name::Symbol, v::Vector) where {T <: APIModel}
     else
         if (vtype <: Vector) && (veltype <: OpenAPI.UnionAPIModel)
             setfield!(o, name, map(veltype, v))
+        elseif (vtype <: Vector) && (veltype <: String)
+            # ensure that elements are converted to String
+            # convert is to do the translation to Union{Nothing,String} when necessary
+            setfield!(o, name, convert(ftype, map(string, v)))
         elseif ftype <: OpenAPI.UnionAPIModel
             setfield!(o, name, ftype(v))
         else

--- a/test/client/allany/AllAnyClient/src/models/model_AnyOfMappedPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_AnyOfMappedPets.jl
@@ -3,7 +3,8 @@
 
 
 
-@doc raw"""
+@doc raw"""AnyOfMappedPets
+
     AnyOfMappedPets(; value=nothing)
 """
 mutable struct AnyOfMappedPets <: OpenAPI.AnyOfAPIModel

--- a/test/client/allany/AllAnyClient/src/models/model_AnyOfPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_AnyOfPets.jl
@@ -3,7 +3,8 @@
 
 
 
-@doc raw"""
+@doc raw"""AnyOfPets
+
     AnyOfPets(; value=nothing)
 """
 mutable struct AnyOfPets <: OpenAPI.AnyOfAPIModel

--- a/test/client/allany/AllAnyClient/src/models/model_Cat.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_Cat.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Cat
+
     Cat(;
         pet_type=nothing,
         hunts=nothing,

--- a/test/client/allany/AllAnyClient/src/models/model_CatAllOf.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_CatAllOf.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Cat_allOf
+
     CatAllOf(;
         hunts=nothing,
         age=nothing,

--- a/test/client/allany/AllAnyClient/src/models/model_Dog.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_Dog.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Dog
+
     Dog(;
         pet_type=nothing,
         bark=nothing,

--- a/test/client/allany/AllAnyClient/src/models/model_DogAllOf.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_DogAllOf.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Dog_allOf
+
     DogAllOf(;
         bark=nothing,
         breed=nothing,

--- a/test/client/allany/AllAnyClient/src/models/model_OneOfMappedPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_OneOfMappedPets.jl
@@ -3,7 +3,8 @@
 
 
 
-@doc raw"""
+@doc raw"""OneOfMappedPets
+
     OneOfMappedPets(; value=nothing)
 """
 mutable struct OneOfMappedPets <: OpenAPI.OneOfAPIModel

--- a/test/client/allany/AllAnyClient/src/models/model_OneOfPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_OneOfPets.jl
@@ -3,7 +3,8 @@
 
 
 
-@doc raw"""
+@doc raw"""OneOfPets
+
     OneOfPets(; value=nothing)
 """
 mutable struct OneOfPets <: OpenAPI.OneOfAPIModel

--- a/test/client/allany/AllAnyClient/src/models/model_Pet.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_Pet.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Pet
+
     Pet(;
         pet_type=nothing,
     )

--- a/test/client/petstore_v2/petstore/src/models/model_ApiResponse.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_ApiResponse.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""ApiResponse
+
     ApiResponse(;
         code=nothing,
         type=nothing,
@@ -34,4 +35,7 @@ function check_required(o::ApiResponse)
 end
 
 function OpenAPI.validate_property(::Type{ ApiResponse }, name::Symbol, val)
+    if name === Symbol("code")
+        OpenAPI.validate_param(name, "ApiResponse", :format, val, "int32")
+    end
 end

--- a/test/client/petstore_v2/petstore/src/models/model_Category.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Category.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Category
+
     Category(;
         id=nothing,
         name=nothing,
@@ -30,4 +31,7 @@ function check_required(o::Category)
 end
 
 function OpenAPI.validate_property(::Type{ Category }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Category", :format, val, "int64")
+    end
 end

--- a/test/client/petstore_v2/petstore/src/models/model_Order.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Order.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Order
+
     Order(;
         id=nothing,
         petId=nothing,
@@ -46,6 +47,18 @@ function check_required(o::Order)
 end
 
 function OpenAPI.validate_property(::Type{ Order }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("petId")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("quantity")
+        OpenAPI.validate_param(name, "Order", :format, val, "int32")
+    end
+    if name === Symbol("shipDate")
+        OpenAPI.validate_param(name, "Order", :format, val, "date-time")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Order", :enum, val, ["placed", "approved", "delivered"])
     end

--- a/test/client/petstore_v2/petstore/src/models/model_Pet.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Pet.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Pet
+
     Pet(;
         id=nothing,
         category=nothing,
@@ -48,6 +49,9 @@ function check_required(o::Pet)
 end
 
 function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Pet", :format, val, "int64")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Pet", :enum, val, ["available", "pending", "sold"])
     end

--- a/test/client/petstore_v2/petstore/src/models/model_Tag.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Tag.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""Tag
+
     Tag(;
         id=nothing,
         name=nothing,
@@ -30,4 +31,7 @@ function check_required(o::Tag)
 end
 
 function OpenAPI.validate_property(::Type{ Tag }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Tag", :format, val, "int64")
+    end
 end

--- a/test/client/petstore_v2/petstore/src/models/model_User.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_User.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""
+@doc raw"""User
+
     User(;
         id=nothing,
         username=nothing,
@@ -54,4 +55,10 @@ function check_required(o::User)
 end
 
 function OpenAPI.validate_property(::Type{ User }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "User", :format, val, "int64")
+    end
+    if name === Symbol("userStatus")
+        OpenAPI.validate_param(name, "User", :format, val, "int32")
+    end
 end

--- a/test/client/petstore_v3/petstore/src/models/model_ApiResponse.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_ApiResponse.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""Describes the result of uploading an image resource
+@doc raw"""ApiResponse
+Describes the result of uploading an image resource
 
     ApiResponse(;
         code=nothing,
@@ -35,4 +36,7 @@ function check_required(o::ApiResponse)
 end
 
 function OpenAPI.validate_property(::Type{ ApiResponse }, name::Symbol, val)
+    if name === Symbol("code")
+        OpenAPI.validate_param(name, "ApiResponse", :format, val, "int32")
+    end
 end

--- a/test/client/petstore_v3/petstore/src/models/model_Category.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Category.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A category for a pet
+@doc raw"""Category
+A category for a pet
 
     Category(;
         id=nothing,
@@ -31,4 +32,7 @@ function check_required(o::Category)
 end
 
 function OpenAPI.validate_property(::Type{ Category }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Category", :format, val, "int64")
+    end
 end

--- a/test/client/petstore_v3/petstore/src/models/model_Order.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Order.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""An order for a pets from the pet store
+@doc raw"""Order
+An order for a pets from the pet store
 
     Order(;
         id=nothing,
@@ -47,6 +48,18 @@ function check_required(o::Order)
 end
 
 function OpenAPI.validate_property(::Type{ Order }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("petId")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("quantity")
+        OpenAPI.validate_param(name, "Order", :format, val, "int32")
+    end
+    if name === Symbol("shipDate")
+        OpenAPI.validate_param(name, "Order", :format, val, "date-time")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Order", :enum, val, ["placed", "approved", "delivered"])
     end

--- a/test/client/petstore_v3/petstore/src/models/model_Pet.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Pet.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A pet for sale in the pet store
+@doc raw"""Pet
+A pet for sale in the pet store
 
     Pet(;
         id=nothing,
@@ -49,6 +50,9 @@ function check_required(o::Pet)
 end
 
 function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Pet", :format, val, "int64")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Pet", :enum, val, ["available", "pending", "sold"])
     end

--- a/test/client/petstore_v3/petstore/src/models/model_Tag.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Tag.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A tag for a pet
+@doc raw"""Tag
+A tag for a pet
 
     Tag(;
         id=nothing,
@@ -31,4 +32,7 @@ function check_required(o::Tag)
 end
 
 function OpenAPI.validate_property(::Type{ Tag }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Tag", :format, val, "int64")
+    end
 end

--- a/test/client/petstore_v3/petstore/src/models/model_User.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_User.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A User who is purchasing from the pet store
+@doc raw"""User
+A User who is purchasing from the pet store
 
     User(;
         id=nothing,
@@ -55,4 +56,10 @@ function check_required(o::User)
 end
 
 function OpenAPI.validate_property(::Type{ User }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "User", :format, val, "int64")
+    end
+    if name === Symbol("userStatus")
+        OpenAPI.validate_param(name, "User", :format, val, "int32")
+    end
 end

--- a/test/client/utilstests.jl
+++ b/test/client/utilstests.jl
@@ -31,6 +31,32 @@ function test_longpoll_exception_check()
     @test OpenAPI.Clients.is_longpoll_timeout(CompositeException([openapiex1, as_taskfailedexception(openapiex1)])) == false
 end
 
+function OpenAPI.val_format(val::AbstractString, ::Val{:testformat})
+    return val == "testvalue"
+end
+function OpenAPI.val_format(val::Integer, ::Val{:testformat})
+    return val == 111
+end
+function OpenAPI.val_format(val::AbstractFloat, ::Val{:testformat})
+    return val == 111.111
+end
+
+function test_custom_format_validations()
+    @test OpenAPI.val_format("testvalue", "testformat")
+    @test !OpenAPI.val_format("invalidvalue", "testformat")
+    @test OpenAPI.val_format("anyvalue", "unknownformat")
+
+    @test OpenAPI.val_format(111, "testformat")
+    @test !OpenAPI.val_format(222, "testformat")
+    @test OpenAPI.val_format(111, "unknownformat")
+
+    @test OpenAPI.val_format(111.111, "testformat")
+    @test !OpenAPI.val_format(222.222, "testformat")
+    @test OpenAPI.val_format(111.111, "unknownformat")
+
+    return nothing
+end
+
 function test_validations()
     # maximum
     @test_throws OpenAPI.ValidationException OpenAPI.validate_param("test_param", "test_model", :maximum, 11, 10, true)
@@ -77,5 +103,7 @@ function test_validations()
     @test OpenAPI.validate_param("test_param", "test_model", :enum, [:a, :b, :b], [:a, :b, :c]) === nothing
     @test_throws OpenAPI.ValidationException OpenAPI.validate_param("test_param", "test_model", :enum, [:a, :b, :c, :d], [:a, :b, :c])
     
+    # custom format Validations
+    test_custom_format_validations()
     return nothing
 end

--- a/test/server/petstore_v2/petstore/src/models/model_ApiResponse.jl
+++ b/test/server/petstore_v2/petstore/src/models/model_ApiResponse.jl
@@ -34,4 +34,7 @@ function check_required(o::ApiResponse)
 end
 
 function OpenAPI.validate_property(::Type{ ApiResponse }, name::Symbol, val)
+    if name === Symbol("code")
+        OpenAPI.validate_param(name, "ApiResponse", :format, val, "int32")
+    end
 end

--- a/test/server/petstore_v2/petstore/src/models/model_Category.jl
+++ b/test/server/petstore_v2/petstore/src/models/model_Category.jl
@@ -30,4 +30,7 @@ function check_required(o::Category)
 end
 
 function OpenAPI.validate_property(::Type{ Category }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Category", :format, val, "int64")
+    end
 end

--- a/test/server/petstore_v2/petstore/src/models/model_Order.jl
+++ b/test/server/petstore_v2/petstore/src/models/model_Order.jl
@@ -46,6 +46,18 @@ function check_required(o::Order)
 end
 
 function OpenAPI.validate_property(::Type{ Order }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("petId")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("quantity")
+        OpenAPI.validate_param(name, "Order", :format, val, "int32")
+    end
+    if name === Symbol("shipDate")
+        OpenAPI.validate_param(name, "Order", :format, val, "date-time")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Order", :enum, val, ["placed", "approved", "delivered"])
     end

--- a/test/server/petstore_v2/petstore/src/models/model_Pet.jl
+++ b/test/server/petstore_v2/petstore/src/models/model_Pet.jl
@@ -48,6 +48,9 @@ function check_required(o::Pet)
 end
 
 function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Pet", :format, val, "int64")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Pet", :enum, val, ["available", "pending", "sold"])
     end

--- a/test/server/petstore_v2/petstore/src/models/model_Tag.jl
+++ b/test/server/petstore_v2/petstore/src/models/model_Tag.jl
@@ -30,4 +30,7 @@ function check_required(o::Tag)
 end
 
 function OpenAPI.validate_property(::Type{ Tag }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Tag", :format, val, "int64")
+    end
 end

--- a/test/server/petstore_v2/petstore/src/models/model_User.jl
+++ b/test/server/petstore_v2/petstore/src/models/model_User.jl
@@ -54,4 +54,10 @@ function check_required(o::User)
 end
 
 function OpenAPI.validate_property(::Type{ User }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "User", :format, val, "int64")
+    end
+    if name === Symbol("userStatus")
+        OpenAPI.validate_param(name, "User", :format, val, "int32")
+    end
 end

--- a/test/server/petstore_v3/petstore/src/models/model_ApiResponse.jl
+++ b/test/server/petstore_v3/petstore/src/models/model_ApiResponse.jl
@@ -35,4 +35,7 @@ function check_required(o::ApiResponse)
 end
 
 function OpenAPI.validate_property(::Type{ ApiResponse }, name::Symbol, val)
+    if name === Symbol("code")
+        OpenAPI.validate_param(name, "ApiResponse", :format, val, "int32")
+    end
 end

--- a/test/server/petstore_v3/petstore/src/models/model_Category.jl
+++ b/test/server/petstore_v3/petstore/src/models/model_Category.jl
@@ -31,4 +31,7 @@ function check_required(o::Category)
 end
 
 function OpenAPI.validate_property(::Type{ Category }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Category", :format, val, "int64")
+    end
 end

--- a/test/server/petstore_v3/petstore/src/models/model_Order.jl
+++ b/test/server/petstore_v3/petstore/src/models/model_Order.jl
@@ -47,6 +47,18 @@ function check_required(o::Order)
 end
 
 function OpenAPI.validate_property(::Type{ Order }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("petId")
+        OpenAPI.validate_param(name, "Order", :format, val, "int64")
+    end
+    if name === Symbol("quantity")
+        OpenAPI.validate_param(name, "Order", :format, val, "int32")
+    end
+    if name === Symbol("shipDate")
+        OpenAPI.validate_param(name, "Order", :format, val, "date-time")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Order", :enum, val, ["placed", "approved", "delivered"])
     end

--- a/test/server/petstore_v3/petstore/src/models/model_Pet.jl
+++ b/test/server/petstore_v3/petstore/src/models/model_Pet.jl
@@ -49,6 +49,9 @@ function check_required(o::Pet)
 end
 
 function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Pet", :format, val, "int64")
+    end
     if name === Symbol("status")
         OpenAPI.validate_param(name, "Pet", :enum, val, ["available", "pending", "sold"])
     end

--- a/test/server/petstore_v3/petstore/src/models/model_Tag.jl
+++ b/test/server/petstore_v3/petstore/src/models/model_Tag.jl
@@ -31,4 +31,7 @@ function check_required(o::Tag)
 end
 
 function OpenAPI.validate_property(::Type{ Tag }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "Tag", :format, val, "int64")
+    end
 end

--- a/test/server/petstore_v3/petstore/src/models/model_User.jl
+++ b/test/server/petstore_v3/petstore/src/models/model_User.jl
@@ -55,4 +55,10 @@ function check_required(o::User)
 end
 
 function OpenAPI.validate_property(::Type{ User }, name::Symbol, val)
+    if name === Symbol("id")
+        OpenAPI.validate_param(name, "User", :format, val, "int64")
+    end
+    if name === Symbol("userStatus")
+        OpenAPI.validate_param(name, "User", :format, val, "int32")
+    end
 end


### PR DESCRIPTION
- add validations for `multipleOf`
- add validations for some `format` specifiers for string, number and integer types
- convert to string when numbers are assigned to string types in models, because some languages may send data with numbers when the format specifier for string type allows it