### PR TITLE
helper methods, validations, handle object types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,8 @@ uuid = "d5e62ea6-ddf3-4d43-8e4c-ad5e6c8bfd7d"
 keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
-authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.1.3"
+authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>", "JuliaHub"]
+version = "0.1.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/client.jl
+++ b/src/client.jl
@@ -514,7 +514,7 @@ summary(model::T) where {T<:APIModel} = print(io, T)
 """
     is_longpoll_timeout(ex::Exception)
 
-Examine the supplied exception and returns true if the reason is timeout
+Examine the supplied exception and return true if the reason is timeout
 of a long polling request. If the exception is a nested exception of type
 CompositeException or TaskFailedException, then navigates through the nested
 exception values to examine the leaves.
@@ -525,5 +525,18 @@ is_longpoll_timeout(ex::CompositeException) = any(is_longpoll_timeout, ex.except
 function is_longpoll_timeout(ex::ApiException)
     ex.status == 200 && match(r"Operation timed out after \d+ milliseconds with \d+ bytes received", ex.reason) !== nothing
 end
+
+"""
+    is_request_interrupted(ex::Exception)
+
+Examine the supplied exception and return true if the reason is that the
+request was interrupted. If the exception is a nested exception of type
+CompositeException or TaskFailedException, then navigates through the nested
+exception values to examine the leaves.
+"""
+is_request_interrupted(ex) = false
+is_request_interrupted(ex::TaskFailedException) = is_request_interrupted(ex.task.exception)
+is_request_interrupted(ex::CompositeException) = any(is_request_interrupted, ex.exceptions)
+is_request_interrupted(ex::InvocationException) = ex.reason == "request was interrupted"
 
 end # module Clients

--- a/src/json.jl
+++ b/src/json.jl
@@ -55,7 +55,9 @@ end
 
 function from_json(o::T, name::Symbol, v) where {T <: APIModel}
     ftype = property_type(T, name)
-    if ZonedDateTime <: ftype
+    if ftype === Any
+        setfield!(o, name, v)
+    elseif ZonedDateTime <: ftype
         setfield!(o, name, str2zoneddatetime(v))
     elseif DateTime <: ftype
         setfield!(o, name, str2datetime(v))

--- a/src/val.jl
+++ b/src/val.jl
@@ -23,7 +23,7 @@ function val_pattern(val::AbstractString, pattern::Regex)
     return !isnothing(match(pattern, val))
 end
 val_format(val, format) = true   # accept any unhandled format
-val_format(val::Union{AbstractString,Integer,AbstractFloat}, format::AbstractString) = val_format(val, Val(Symbol(format)))
+val_format(val, format::AbstractString) = val_format(val, Val(Symbol(format)))
 val_format(val::AbstractString, ::Val{:date}) = str2date(val) isa Date
 val_format(val::AbstractString, ::Val{Symbol("date-time")}) = str2datetime(val) isa DateTime
 val_format(val::AbstractString, ::Val{:byte}) = try

--- a/test/client/runtests.jl
+++ b/test/client/runtests.jl
@@ -12,6 +12,7 @@ function runtests()
     @testset "Client" begin
         @testset "Utils" begin
             test_longpoll_exception_check()
+            test_request_interrupted_exception_check()
         end
         @testset "Validations" begin
             test_validations()

--- a/test/client/utilstests.jl
+++ b/test/client/utilstests.jl
@@ -31,6 +31,23 @@ function test_longpoll_exception_check()
     @test OpenAPI.Clients.is_longpoll_timeout(CompositeException([openapiex1, as_taskfailedexception(openapiex1)])) == false
 end
 
+function test_request_interrupted_exception_check()
+    ex1 = OpenAPI.InvocationException("request was interrupted")
+    ex2 = ArgumentError("request interrupted")
+    ex3 = OpenAPI.InvocationException("not request interrupted")
+
+    @test OpenAPI.Clients.is_request_interrupted(ex1)
+    @test !OpenAPI.Clients.is_request_interrupted(ex2)
+    @test !OpenAPI.Clients.is_request_interrupted(ex3)
+
+    @test OpenAPI.Clients.is_request_interrupted(as_taskfailedexception(ex1))
+    @test !OpenAPI.Clients.is_request_interrupted(as_taskfailedexception(ex2))
+    @test !OpenAPI.Clients.is_request_interrupted(as_taskfailedexception(ex3))
+
+    @test OpenAPI.Clients.is_request_interrupted(CompositeException([ex1, ex2]))
+    @test !OpenAPI.Clients.is_request_interrupted(CompositeException([ex2, ex3]))
+end
+
 function OpenAPI.val_format(val::AbstractString, ::Val{:testformat})
     return val == "testvalue"
 end


### PR DESCRIPTION
- Add helper API `is_request_interrupted` to check if the error is because a streamign request was interrupted by the caller
- Handle JSON marshalling for plain `object` types that are generated as `Any`
- Fix default `val_format` implementation, it was too wide and did not allow customization