### PR TITLE
avoid error with HTTP/2 servers, update readme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>", "JuliaHub"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check out [OpenAPI-Spec](https://github.com/OAI/OpenAPI-Specification) for addit
 
 Use [instructions](https://openapi-generator.tech/docs/generators) provided for the Julia OpenAPI code generator plugin to generate Julia code.
 
-> Note: It requires the Julia code generator hosted in [this forked branch](https://github.com/JuliaComputing/openapi-generator/tree/juliahub/juliacodegen) of the OpenAPI code generator. The plan is to submit it for inclusion in the upstream repo soon.
+> Note: It requires the master branch of [openapi-generator](https://github.com/OpenAPITools/openapi-generator) until it is included in the next release. It is also hosted in [this forked branch](https://github.com/JuliaComputing/openapi-generator/tree/juliahub/juliacodegen) until then.
 
 ## Generated Code Structure
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -101,11 +101,15 @@ struct Client
             get_return_type::Function=get_api_return_type,
             long_polling_timeout::Int=DEFAULT_LONGPOLL_TIMEOUT_SECS,
             timeout::Int=DEFAULT_TIMEOUT_SECS,
-            pre_request_hook::Function=noop_pre_request_hook)
-        clntoptions = Dict{Symbol,Any}(:throw=>false, :verbose=>false)
+            pre_request_hook::Function=noop_pre_request_hook,
+            verbose::Bool=false,
+        )
+        clntoptions = Dict{Symbol,Any}(:throw=>false, :verbose=>verbose)
         downloader = Downloads.Downloader()
         downloader.easy_hook = (easy, opts) -> begin
             Downloads.Curl.setopt(easy, LibCURL.CURLOPT_LOW_SPEED_TIME, long_polling_timeout)
+            # disable ALPN to support servers that enable both HTTP/2 and HTTP/1.1 on same port
+            Downloads.Curl.setopt(easy, LibCURL.CURLOPT_SSL_ENABLE_ALPN, 0)
         end
         new(root, headers, get_return_type, clntoptions, downloader, Ref{Int}(timeout), pre_request_hook, long_polling_timeout)
     end

--- a/test/client/allany/AllAnyClient/src/apis/api_DefaultApi.jl
+++ b/test/client/allany/AllAnyClient/src/apis/api_DefaultApi.jl
@@ -11,12 +11,12 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ DefaultApi }) = "http://localhost"
 
-const _returntypes_echo_anyof_mapped_pets_post = Dict{Regex,Type}(
+const _returntypes_echo_anyof_mapped_pets_post_DefaultApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => AnyOfMappedPets,
 )
 
 function _oacinternal_echo_anyof_mapped_pets_post(_api::DefaultApi, any_of_mapped_pets::AnyOfMappedPets; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_anyof_mapped_pets_post, "/echo_anyof_mapped_pets", [], any_of_mapped_pets)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_anyof_mapped_pets_post_DefaultApi, "/echo_anyof_mapped_pets", [], any_of_mapped_pets)
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -37,12 +37,12 @@ function echo_anyof_mapped_pets_post(_api::DefaultApi, response_stream::Channel,
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_echo_anyof_pets_post = Dict{Regex,Type}(
+const _returntypes_echo_anyof_pets_post_DefaultApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => AnyOfPets,
 )
 
 function _oacinternal_echo_anyof_pets_post(_api::DefaultApi, any_of_pets::AnyOfPets; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_anyof_pets_post, "/echo_anyof_pets", [], any_of_pets)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_anyof_pets_post_DefaultApi, "/echo_anyof_pets", [], any_of_pets)
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -63,12 +63,12 @@ function echo_anyof_pets_post(_api::DefaultApi, response_stream::Channel, any_of
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_echo_oneof_mapped_pets_post = Dict{Regex,Type}(
+const _returntypes_echo_oneof_mapped_pets_post_DefaultApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => OneOfMappedPets,
 )
 
 function _oacinternal_echo_oneof_mapped_pets_post(_api::DefaultApi, one_of_mapped_pets::OneOfMappedPets; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_oneof_mapped_pets_post, "/echo_oneof_mapped_pets", [], one_of_mapped_pets)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_oneof_mapped_pets_post_DefaultApi, "/echo_oneof_mapped_pets", [], one_of_mapped_pets)
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -89,12 +89,12 @@ function echo_oneof_mapped_pets_post(_api::DefaultApi, response_stream::Channel,
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_echo_oneof_pets_post = Dict{Regex,Type}(
+const _returntypes_echo_oneof_pets_post_DefaultApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => OneOfPets,
 )
 
 function _oacinternal_echo_oneof_pets_post(_api::DefaultApi, one_of_pets::OneOfPets; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_oneof_pets_post, "/echo_oneof_pets", [], one_of_pets)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_echo_oneof_pets_post_DefaultApi, "/echo_oneof_pets", [], one_of_pets)
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx

--- a/test/client/allany/AllAnyClient/src/models/model_AnyOfMappedPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_AnyOfMappedPets.jl
@@ -22,3 +22,4 @@ function OpenAPI.property_type(::Type{ AnyOfMappedPets }, name::Symbol, json::Di
     end
     throw(OpenAPI.ValidationException("Invalid discriminator value: $discriminator for AnyOfMappedPets"))
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_AnyOfPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_AnyOfPets.jl
@@ -22,3 +22,4 @@ function OpenAPI.property_type(::Type{ AnyOfPets }, name::Symbol, json::Dict{Str
     end
     throw(OpenAPI.ValidationException("Invalid discriminator value: $discriminator for AnyOfPets"))
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_Cat.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_Cat.jl
@@ -37,3 +37,4 @@ end
 
 function OpenAPI.validate_property(::Type{ Cat }, name::Symbol, val)
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_CatAllOf.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_CatAllOf.jl
@@ -32,3 +32,4 @@ end
 
 function OpenAPI.validate_property(::Type{ CatAllOf }, name::Symbol, val)
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_Dog.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_Dog.jl
@@ -40,3 +40,4 @@ function OpenAPI.validate_property(::Type{ Dog }, name::Symbol, val)
         OpenAPI.validate_param(name, "Dog", :enum, val, ["Dingo", "Husky", "Retriever", "Shepherd"])
     end
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_DogAllOf.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_DogAllOf.jl
@@ -35,3 +35,4 @@ function OpenAPI.validate_property(::Type{ DogAllOf }, name::Symbol, val)
         OpenAPI.validate_param(name, "DogAllOf", :enum, val, ["Dingo", "Husky", "Retriever", "Shepherd"])
     end
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_OneOfMappedPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_OneOfMappedPets.jl
@@ -22,3 +22,4 @@ function OpenAPI.property_type(::Type{ OneOfMappedPets }, name::Symbol, json::Di
     end
     throw(OpenAPI.ValidationException("Invalid discriminator value: $discriminator for OneOfMappedPets"))
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_OneOfPets.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_OneOfPets.jl
@@ -22,3 +22,4 @@ function OpenAPI.property_type(::Type{ OneOfPets }, name::Symbol, json::Dict{Str
     end
     throw(OpenAPI.ValidationException("Invalid discriminator value: $discriminator for OneOfPets"))
 end
+

--- a/test/client/allany/AllAnyClient/src/models/model_Pet.jl
+++ b/test/client/allany/AllAnyClient/src/models/model_Pet.jl
@@ -29,3 +29,4 @@ end
 
 function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
 end
+

--- a/test/client/petstore_v2/petstore/src/apis/api_PetApi.jl
+++ b/test/client/petstore_v2/petstore/src/apis/api_PetApi.jl
@@ -11,12 +11,12 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ PetApi }) = "https://petstore.swagger.io/v2"
 
-const _returntypes_add_pet = Dict{Regex,Type}(
+const _returntypes_add_pet_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("405", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_add_pet(_api::PetApi, body::Pet; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_add_pet, "/pet", ["petstore_auth", ], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_add_pet_PetApi, "/pet", ["petstore_auth", ], body)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", "application/xml", ] : [_mediaType])
     return _ctx
@@ -39,13 +39,13 @@ function add_pet(_api::PetApi, response_stream::Channel, body::Pet; _mediaType=n
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_delete_pet = Dict{Regex,Type}(
+const _returntypes_delete_pet_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_delete_pet(_api::PetApi, pet_id::Int64; api_key=nothing, _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_pet, "/pet/{petId}", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_pet_PetApi, "/pet/{petId}", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.header, "api_key", api_key)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
@@ -71,13 +71,13 @@ function delete_pet(_api::PetApi, response_stream::Channel, pet_id::Int64; api_k
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_find_pets_by_status = Dict{Regex,Type}(
+const _returntypes_find_pets_by_status_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Vector{Pet},
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_find_pets_by_status(_api::PetApi, status::Vector{String}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_status, "/pet/findByStatus", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_status_PetApi, "/pet/findByStatus", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.query, "status", status)  # type Vector{String}
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -103,13 +103,13 @@ function find_pets_by_status(_api::PetApi, response_stream::Channel, status::Vec
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_find_pets_by_tags = Dict{Regex,Type}(
+const _returntypes_find_pets_by_tags_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Vector{Pet},
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_find_pets_by_tags(_api::PetApi, tags::Vector{String}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_tags, "/pet/findByTags", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_tags_PetApi, "/pet/findByTags", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.query, "tags", tags)  # type Vector{String}
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -135,14 +135,14 @@ function find_pets_by_tags(_api::PetApi, response_stream::Channel, tags::Vector{
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_pet_by_id = Dict{Regex,Type}(
+const _returntypes_get_pet_by_id_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Pet,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_get_pet_by_id(_api::PetApi, pet_id::Int64; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_pet_by_id, "/pet/{petId}", ["api_key", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_pet_by_id_PetApi, "/pet/{petId}", ["api_key", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -168,14 +168,14 @@ function get_pet_by_id(_api::PetApi, response_stream::Channel, pet_id::Int64; _m
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_update_pet = Dict{Regex,Type}(
+const _returntypes_update_pet_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("405", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_update_pet(_api::PetApi, body::Pet; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_pet, "/pet", ["petstore_auth", ], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_pet_PetApi, "/pet", ["petstore_auth", ], body)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", "application/xml", ] : [_mediaType])
     return _ctx
@@ -198,12 +198,12 @@ function update_pet(_api::PetApi, response_stream::Channel, body::Pet; _mediaTyp
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_update_pet_with_form = Dict{Regex,Type}(
+const _returntypes_update_pet_with_form_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("405", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_update_pet_with_form(_api::PetApi, pet_id::Int64; name=nothing, status=nothing, _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_update_pet_with_form, "/pet/{petId}", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_update_pet_with_form_PetApi, "/pet/{petId}", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.form, "name", name)  # type String
     OpenAPI.Clients.set_param(_ctx.form, "status", status)  # type String
@@ -231,12 +231,12 @@ function update_pet_with_form(_api::PetApi, response_stream::Channel, pet_id::In
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_upload_file = Dict{Regex,Type}(
+const _returntypes_upload_file_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => ApiResponse,
 )
 
 function _oacinternal_upload_file(_api::PetApi, pet_id::Int64; additional_metadata=nothing, file=nothing, _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_upload_file, "/pet/{petId}/uploadImage", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_upload_file_PetApi, "/pet/{petId}/uploadImage", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.form, "additionalMetadata", additional_metadata)  # type String
     OpenAPI.Clients.set_param(_ctx.file, "file", file)  # type String

--- a/test/client/petstore_v2/petstore/src/apis/api_StoreApi.jl
+++ b/test/client/petstore_v2/petstore/src/apis/api_StoreApi.jl
@@ -11,7 +11,7 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ StoreApi }) = "https://petstore.swagger.io/v2"
 
-const _returntypes_delete_order = Dict{Regex,Type}(
+const _returntypes_delete_order_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
@@ -19,7 +19,7 @@ const _returntypes_delete_order = Dict{Regex,Type}(
 function _oacinternal_delete_order(_api::StoreApi, order_id::Int64; _mediaType=nothing)
     OpenAPI.validate_param("order_id", "delete_order", :minimum, order_id, 1, false)
 
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_order, "/store/order/{orderId}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_order_StoreApi, "/store/order/{orderId}", [])
     OpenAPI.Clients.set_param(_ctx.path, "orderId", order_id)  # type Int64
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -45,12 +45,12 @@ function delete_order(_api::StoreApi, response_stream::Channel, order_id::Int64;
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_inventory = Dict{Regex,Type}(
+const _returntypes_get_inventory_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Dict{String, Int64},
 )
 
 function _oacinternal_get_inventory(_api::StoreApi; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_inventory, "/store/inventory", ["api_key", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_inventory_StoreApi, "/store/inventory", ["api_key", ])
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
     return _ctx
@@ -74,7 +74,7 @@ function get_inventory(_api::StoreApi, response_stream::Channel; _mediaType=noth
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_order_by_id = Dict{Regex,Type}(
+const _returntypes_get_order_by_id_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Order,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
@@ -84,7 +84,7 @@ function _oacinternal_get_order_by_id(_api::StoreApi, order_id::Int64; _mediaTyp
     OpenAPI.validate_param("order_id", "get_order_by_id", :maximum, order_id, 10, false)
     OpenAPI.validate_param("order_id", "get_order_by_id", :minimum, order_id, 1, false)
 
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_order_by_id, "/store/order/{orderId}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_order_by_id_StoreApi, "/store/order/{orderId}", [])
     OpenAPI.Clients.set_param(_ctx.path, "orderId", order_id)  # type Int64
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -110,13 +110,13 @@ function get_order_by_id(_api::StoreApi, response_stream::Channel, order_id::Int
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_place_order = Dict{Regex,Type}(
+const _returntypes_place_order_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Order,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_place_order(_api::StoreApi, body::Order; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_place_order, "/store/order", [], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_place_order_StoreApi, "/store/order", [], body)
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx

--- a/test/client/petstore_v2/petstore/src/apis/api_UserApi.jl
+++ b/test/client/petstore_v2/petstore/src/apis/api_UserApi.jl
@@ -11,12 +11,12 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ UserApi }) = "https://petstore.swagger.io/v2"
 
-const _returntypes_create_user = Dict{Regex,Type}(
+const _returntypes_create_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_create_user(_api::UserApi, body::User; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_user, "/user", [], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_user_UserApi, "/user", [], body)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -41,12 +41,12 @@ function create_user(_api::UserApi, response_stream::Channel, body::User; _media
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_create_users_with_array_input = Dict{Regex,Type}(
+const _returntypes_create_users_with_array_input_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_create_users_with_array_input(_api::UserApi, body::Vector{User}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_array_input, "/user/createWithArray", [], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_array_input_UserApi, "/user/createWithArray", [], body)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -69,12 +69,12 @@ function create_users_with_array_input(_api::UserApi, response_stream::Channel, 
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_create_users_with_list_input = Dict{Regex,Type}(
+const _returntypes_create_users_with_list_input_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_create_users_with_list_input(_api::UserApi, body::Vector{User}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_list_input, "/user/createWithList", [], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_list_input_UserApi, "/user/createWithList", [], body)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -97,13 +97,13 @@ function create_users_with_list_input(_api::UserApi, response_stream::Channel, b
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_delete_user = Dict{Regex,Type}(
+const _returntypes_delete_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_delete_user(_api::UserApi, username::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_user, "/user/{username}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_user_UserApi, "/user/{username}", [])
     OpenAPI.Clients.set_param(_ctx.path, "username", username)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -129,14 +129,14 @@ function delete_user(_api::UserApi, response_stream::Channel, username::String; 
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_user_by_name = Dict{Regex,Type}(
+const _returntypes_get_user_by_name_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => User,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_get_user_by_name(_api::UserApi, username::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_user_by_name, "/user/{username}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_user_by_name_UserApi, "/user/{username}", [])
     OpenAPI.Clients.set_param(_ctx.path, "username", username)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -160,13 +160,13 @@ function get_user_by_name(_api::UserApi, response_stream::Channel, username::Str
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_login_user = Dict{Regex,Type}(
+const _returntypes_login_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => String,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_login_user(_api::UserApi, username::String, password::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_login_user, "/user/login", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_login_user_UserApi, "/user/login", [])
     OpenAPI.Clients.set_param(_ctx.query, "username", username)  # type String
     OpenAPI.Clients.set_param(_ctx.query, "password", password)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", "application/xml", ])
@@ -192,12 +192,12 @@ function login_user(_api::UserApi, response_stream::Channel, username::String, p
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_logout_user = Dict{Regex,Type}(
+const _returntypes_logout_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_logout_user(_api::UserApi; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_logout_user, "/user/logout", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_logout_user_UserApi, "/user/logout", [])
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
     return _ctx
@@ -219,13 +219,13 @@ function logout_user(_api::UserApi, response_stream::Channel; _mediaType=nothing
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_update_user = Dict{Regex,Type}(
+const _returntypes_update_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_update_user(_api::UserApi, username::String, body::User; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_user, "/user/{username}", [], body)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_user_UserApi, "/user/{username}", [], body)
     OpenAPI.Clients.set_param(_ctx.path, "username", username)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])

--- a/test/client/petstore_v2/petstore/src/models/model_ApiResponse.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_ApiResponse.jl
@@ -39,3 +39,4 @@ function OpenAPI.validate_property(::Type{ ApiResponse }, name::Symbol, val)
         OpenAPI.validate_param(name, "ApiResponse", :format, val, "int32")
     end
 end
+

--- a/test/client/petstore_v2/petstore/src/models/model_Category.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Category.jl
@@ -35,3 +35,4 @@ function OpenAPI.validate_property(::Type{ Category }, name::Symbol, val)
         OpenAPI.validate_param(name, "Category", :format, val, "int64")
     end
 end
+

--- a/test/client/petstore_v2/petstore/src/models/model_Order.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Order.jl
@@ -63,3 +63,4 @@ function OpenAPI.validate_property(::Type{ Order }, name::Symbol, val)
         OpenAPI.validate_param(name, "Order", :enum, val, ["placed", "approved", "delivered"])
     end
 end
+

--- a/test/client/petstore_v2/petstore/src/models/model_Pet.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Pet.jl
@@ -56,3 +56,4 @@ function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
         OpenAPI.validate_param(name, "Pet", :enum, val, ["available", "pending", "sold"])
     end
 end
+

--- a/test/client/petstore_v2/petstore/src/models/model_Tag.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_Tag.jl
@@ -35,3 +35,4 @@ function OpenAPI.validate_property(::Type{ Tag }, name::Symbol, val)
         OpenAPI.validate_param(name, "Tag", :format, val, "int64")
     end
 end
+

--- a/test/client/petstore_v2/petstore/src/models/model_User.jl
+++ b/test/client/petstore_v2/petstore/src/models/model_User.jl
@@ -62,3 +62,4 @@ function OpenAPI.validate_property(::Type{ User }, name::Symbol, val)
         OpenAPI.validate_param(name, "User", :format, val, "int32")
     end
 end
+

--- a/test/client/petstore_v3/petstore/src/apis/api_PetApi.jl
+++ b/test/client/petstore_v3/petstore/src/apis/api_PetApi.jl
@@ -11,12 +11,12 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ PetApi }) = "/v3"
 
-const _returntypes_add_pet = Dict{Regex,Type}(
+const _returntypes_add_pet_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("405", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_add_pet(_api::PetApi, pet::Pet; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_add_pet, "/pet", ["petstore_auth", ], pet)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_add_pet_PetApi, "/pet", ["petstore_auth", ], pet)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", "application/xml", ] : [_mediaType])
     return _ctx
@@ -39,12 +39,12 @@ function add_pet(_api::PetApi, response_stream::Channel, pet::Pet; _mediaType=no
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_delete_pet = Dict{Regex,Type}(
+const _returntypes_delete_pet_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_delete_pet(_api::PetApi, pet_id::Int64; api_key=nothing, _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_pet, "/pet/{petId}", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_pet_PetApi, "/pet/{petId}", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.header, "api_key", api_key)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
@@ -70,13 +70,13 @@ function delete_pet(_api::PetApi, response_stream::Channel, pet_id::Int64; api_k
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_find_pets_by_status = Dict{Regex,Type}(
+const _returntypes_find_pets_by_status_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Vector{Pet},
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_find_pets_by_status(_api::PetApi, status::Vector{String}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_status, "/pet/findByStatus", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_status_PetApi, "/pet/findByStatus", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.query, "status", status)  # type Vector{String}
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -102,13 +102,13 @@ function find_pets_by_status(_api::PetApi, response_stream::Channel, status::Vec
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_find_pets_by_tags = Dict{Regex,Type}(
+const _returntypes_find_pets_by_tags_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Vector{Pet},
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_find_pets_by_tags(_api::PetApi, tags::Vector{String}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_tags, "/pet/findByTags", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_find_pets_by_tags_PetApi, "/pet/findByTags", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.query, "tags", tags)  # type Vector{String}
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -134,14 +134,14 @@ function find_pets_by_tags(_api::PetApi, response_stream::Channel, tags::Vector{
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_pet_by_id = Dict{Regex,Type}(
+const _returntypes_get_pet_by_id_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Pet,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_get_pet_by_id(_api::PetApi, pet_id::Int64; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_pet_by_id, "/pet/{petId}", ["api_key", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_pet_by_id_PetApi, "/pet/{petId}", ["api_key", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -167,14 +167,14 @@ function get_pet_by_id(_api::PetApi, response_stream::Channel, pet_id::Int64; _m
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_update_pet = Dict{Regex,Type}(
+const _returntypes_update_pet_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("405", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_update_pet(_api::PetApi, pet::Pet; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_pet, "/pet", ["petstore_auth", ], pet)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_pet_PetApi, "/pet", ["petstore_auth", ], pet)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", "application/xml", ] : [_mediaType])
     return _ctx
@@ -197,12 +197,12 @@ function update_pet(_api::PetApi, response_stream::Channel, pet::Pet; _mediaType
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_update_pet_with_form = Dict{Regex,Type}(
+const _returntypes_update_pet_with_form_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("405", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_update_pet_with_form(_api::PetApi, pet_id::Int64; name=nothing, status=nothing, _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_update_pet_with_form, "/pet/{petId}", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_update_pet_with_form_PetApi, "/pet/{petId}", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.form, "name", name)  # type String
     OpenAPI.Clients.set_param(_ctx.form, "status", status)  # type String
@@ -230,12 +230,12 @@ function update_pet_with_form(_api::PetApi, response_stream::Channel, pet_id::In
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_upload_file = Dict{Regex,Type}(
+const _returntypes_upload_file_PetApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => ApiResponse,
 )
 
 function _oacinternal_upload_file(_api::PetApi, pet_id::Int64; additional_metadata=nothing, file=nothing, _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_upload_file, "/pet/{petId}/uploadImage", ["petstore_auth", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_upload_file_PetApi, "/pet/{petId}/uploadImage", ["petstore_auth", ])
     OpenAPI.Clients.set_param(_ctx.path, "petId", pet_id)  # type Int64
     OpenAPI.Clients.set_param(_ctx.form, "additionalMetadata", additional_metadata)  # type String
     OpenAPI.Clients.set_param(_ctx.file, "file", file)  # type String

--- a/test/client/petstore_v3/petstore/src/apis/api_StoreApi.jl
+++ b/test/client/petstore_v3/petstore/src/apis/api_StoreApi.jl
@@ -11,13 +11,13 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ StoreApi }) = "/v3"
 
-const _returntypes_delete_order = Dict{Regex,Type}(
+const _returntypes_delete_order_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_delete_order(_api::StoreApi, order_id::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_order, "/store/order/{orderId}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_order_StoreApi, "/store/order/{orderId}", [])
     OpenAPI.Clients.set_param(_ctx.path, "orderId", order_id)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -43,12 +43,12 @@ function delete_order(_api::StoreApi, response_stream::Channel, order_id::String
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_inventory = Dict{Regex,Type}(
+const _returntypes_get_inventory_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Dict{String, Int64},
 )
 
 function _oacinternal_get_inventory(_api::StoreApi; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_inventory, "/store/inventory", ["api_key", ])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_inventory_StoreApi, "/store/inventory", ["api_key", ])
     OpenAPI.Clients.set_header_accept(_ctx, ["application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
     return _ctx
@@ -72,7 +72,7 @@ function get_inventory(_api::StoreApi, response_stream::Channel; _mediaType=noth
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_order_by_id = Dict{Regex,Type}(
+const _returntypes_get_order_by_id_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Order,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
@@ -82,7 +82,7 @@ function _oacinternal_get_order_by_id(_api::StoreApi, order_id::Int64; _mediaTyp
     OpenAPI.validate_param("order_id", "get_order_by_id", :maximum, order_id, 5, false)
     OpenAPI.validate_param("order_id", "get_order_by_id", :minimum, order_id, 1, false)
 
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_order_by_id, "/store/order/{orderId}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_order_by_id_StoreApi, "/store/order/{orderId}", [])
     OpenAPI.Clients.set_param(_ctx.path, "orderId", order_id)  # type Int64
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -108,13 +108,13 @@ function get_order_by_id(_api::StoreApi, response_stream::Channel, order_id::Int
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_place_order = Dict{Regex,Type}(
+const _returntypes_place_order_StoreApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => Order,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_place_order(_api::StoreApi, order::Order; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_place_order, "/store/order", [], order)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_place_order_StoreApi, "/store/order", [], order)
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx

--- a/test/client/petstore_v3/petstore/src/apis/api_UserApi.jl
+++ b/test/client/petstore_v3/petstore/src/apis/api_UserApi.jl
@@ -11,12 +11,12 @@ This can be used to construct the `OpenAPI.Clients.Client` instance.
 """
 basepath(::Type{ UserApi }) = "/v3"
 
-const _returntypes_create_user = Dict{Regex,Type}(
+const _returntypes_create_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_create_user(_api::UserApi, user::User; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_user, "/user", [], user)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_user_UserApi, "/user", [], user)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -41,12 +41,12 @@ function create_user(_api::UserApi, response_stream::Channel, user::User; _media
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_create_users_with_array_input = Dict{Regex,Type}(
+const _returntypes_create_users_with_array_input_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_create_users_with_array_input(_api::UserApi, user::Vector{User}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_array_input, "/user/createWithArray", [], user)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_array_input_UserApi, "/user/createWithArray", [], user)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -69,12 +69,12 @@ function create_users_with_array_input(_api::UserApi, response_stream::Channel, 
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_create_users_with_list_input = Dict{Regex,Type}(
+const _returntypes_create_users_with_list_input_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_create_users_with_list_input(_api::UserApi, user::Vector{User}; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_list_input, "/user/createWithList", [], user)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "POST", _returntypes_create_users_with_list_input_UserApi, "/user/createWithList", [], user)
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])
     return _ctx
@@ -97,13 +97,13 @@ function create_users_with_list_input(_api::UserApi, response_stream::Channel, u
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_delete_user = Dict{Regex,Type}(
+const _returntypes_delete_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_delete_user(_api::UserApi, username::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_user, "/user/{username}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "DELETE", _returntypes_delete_user_UserApi, "/user/{username}", [])
     OpenAPI.Clients.set_param(_ctx.path, "username", username)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -129,14 +129,14 @@ function delete_user(_api::UserApi, response_stream::Channel, username::String; 
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_get_user_by_name = Dict{Regex,Type}(
+const _returntypes_get_user_by_name_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => User,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_get_user_by_name(_api::UserApi, username::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_user_by_name, "/user/{username}", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_get_user_by_name_UserApi, "/user/{username}", [])
     OpenAPI.Clients.set_param(_ctx.path, "username", username)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
@@ -160,13 +160,13 @@ function get_user_by_name(_api::UserApi, response_stream::Channel, username::Str
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_login_user = Dict{Regex,Type}(
+const _returntypes_login_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("200", "x"=>".") * "\$") => String,
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_login_user(_api::UserApi, username::String, password::String; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_login_user, "/user/login", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_login_user_UserApi, "/user/login", [])
     OpenAPI.Clients.set_param(_ctx.query, "username", username)  # type String
     OpenAPI.Clients.set_param(_ctx.query, "password", password)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, ["application/xml", "application/json", ])
@@ -192,12 +192,12 @@ function login_user(_api::UserApi, response_stream::Channel, username::String, p
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_logout_user = Dict{Regex,Type}(
+const _returntypes_logout_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("0", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_logout_user(_api::UserApi; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_logout_user, "/user/logout", [])
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "GET", _returntypes_logout_user_UserApi, "/user/logout", [])
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? [] : [_mediaType])
     return _ctx
@@ -219,13 +219,13 @@ function logout_user(_api::UserApi, response_stream::Channel; _mediaType=nothing
     return OpenAPI.Clients.exec(_ctx, response_stream)
 end
 
-const _returntypes_update_user = Dict{Regex,Type}(
+const _returntypes_update_user_UserApi = Dict{Regex,Type}(
     Regex("^" * replace("400", "x"=>".") * "\$") => Nothing,
     Regex("^" * replace("404", "x"=>".") * "\$") => Nothing,
 )
 
 function _oacinternal_update_user(_api::UserApi, username::String, user::User; _mediaType=nothing)
-    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_user, "/user/{username}", [], user)
+    _ctx = OpenAPI.Clients.Ctx(_api.client, "PUT", _returntypes_update_user_UserApi, "/user/{username}", [], user)
     OpenAPI.Clients.set_param(_ctx.path, "username", username)  # type String
     OpenAPI.Clients.set_header_accept(_ctx, [])
     OpenAPI.Clients.set_header_content_type(_ctx, (_mediaType === nothing) ? ["application/json", ] : [_mediaType])

--- a/test/client/petstore_v3/petstore/src/models/model_ApiResponse.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_ApiResponse.jl
@@ -40,3 +40,4 @@ function OpenAPI.validate_property(::Type{ ApiResponse }, name::Symbol, val)
         OpenAPI.validate_param(name, "ApiResponse", :format, val, "int32")
     end
 end
+

--- a/test/client/petstore_v3/petstore/src/models/model_Category.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Category.jl
@@ -36,3 +36,4 @@ function OpenAPI.validate_property(::Type{ Category }, name::Symbol, val)
         OpenAPI.validate_param(name, "Category", :format, val, "int64")
     end
 end
+

--- a/test/client/petstore_v3/petstore/src/models/model_Order.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Order.jl
@@ -64,3 +64,4 @@ function OpenAPI.validate_property(::Type{ Order }, name::Symbol, val)
         OpenAPI.validate_param(name, "Order", :enum, val, ["placed", "approved", "delivered"])
     end
 end
+

--- a/test/client/petstore_v3/petstore/src/models/model_Pet.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Pet.jl
@@ -57,3 +57,4 @@ function OpenAPI.validate_property(::Type{ Pet }, name::Symbol, val)
         OpenAPI.validate_param(name, "Pet", :enum, val, ["available", "pending", "sold"])
     end
 end
+

--- a/test/client/petstore_v3/petstore/src/models/model_Tag.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_Tag.jl
@@ -36,3 +36,4 @@ function OpenAPI.validate_property(::Type{ Tag }, name::Symbol, val)
         OpenAPI.validate_param(name, "Tag", :format, val, "int64")
     end
 end
+

--- a/test/client/petstore_v3/petstore/src/models/model_User.jl
+++ b/test/client/petstore_v3/petstore/src/models/model_User.jl
@@ -63,3 +63,4 @@ function OpenAPI.validate_property(::Type{ User }, name::Symbol, val)
         OpenAPI.validate_param(name, "User", :format, val, "int32")
     end
 end
+


### PR DESCRIPTION
- disable HTTP/2 negotiation, unsupported as of now
- update note about openapi-generator status