### PR TITLE
specialize hasproperty for APIModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>", "JuliaHub"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/OpenAPI.jl
+++ b/src/OpenAPI.jl
@@ -2,7 +2,7 @@ module OpenAPI
 
 using HTTP, JSON, URIs, Dates, TimeZones, Base64
 
-import Base: getindex, keys, length, iterate
+import Base: getindex, keys, length, iterate, hasproperty
 import JSON: lower
 
 include("commontypes.jl")

--- a/src/client.jl
+++ b/src/client.jl
@@ -490,6 +490,7 @@ function haspropertyat(o::T, path...) where {T<:APIModel}
     ret = hasproperty(o, p1)
     rempath = path[2:end]
     (length(rempath) == 0) && (return ret)
+    ret || (return false)
 
     val = getproperty(o, p1)
     if isa(val, Vector)
@@ -507,6 +508,8 @@ function haspropertyat(o::T, path...) where {T<:APIModel}
     (length(rempath) == 0) && (return ret)
     haspropertyat(val, rempath...)
 end
+
+Base.hasproperty(o::T, name::Symbol) where {T<:APIModel} = ((name in propertynames(o)) && (getproperty(o, name) !== nothing))
 
 convert(::Type{T}, json::Dict{String,Any}) where {T<:APIModel} = from_json(T, json)
 convert(::Type{T}, v::Nothing) where {T<:APIModel} = T()

--- a/test/client/runtests.jl
+++ b/test/client/runtests.jl
@@ -15,6 +15,7 @@ function runtests()
             test_request_interrupted_exception_check()
             test_date()
             test_misc()
+            test_has_property()
         end
         @testset "Validations" begin
             test_validations()

--- a/test/client/utilstests.jl
+++ b/test/client/utilstests.jl
@@ -159,6 +159,42 @@ function test_validations()
     return nothing
 end
 
+struct TestHasPropertyInner <: OpenAPI.APIModel
+    testval::Union{Nothing,String}
+
+    function TestHasPropertyInner(; testval=nothing)
+        return new(testval)
+    end
+end
+
+struct TestHasProperty <: OpenAPI.APIModel
+    inner::Union{Nothing,TestHasPropertyInner}
+
+    function TestHasProperty(; inner=nothing)
+        return new(inner)
+    end
+end
+
+function test_has_property()
+    teststruct = TestHasProperty()
+
+    @test !OpenAPI.Clients.haspropertyat(teststruct, :inner, :testval)
+    @test !OpenAPI.Clients.haspropertyat(teststruct, "inner", "testval")
+    @test !OpenAPI.Clients.haspropertyat(teststruct, :inner)
+
+    teststruct = TestHasProperty(; inner=TestHasPropertyInner())
+    @test !OpenAPI.Clients.haspropertyat(teststruct, :inner, :testval)
+    @test !OpenAPI.Clients.haspropertyat(teststruct, "inner", "testval")
+    @test OpenAPI.Clients.haspropertyat(teststruct, :inner)
+
+    teststruct = TestHasProperty(; inner=TestHasPropertyInner(; testval="test"))
+    @test OpenAPI.Clients.haspropertyat(teststruct, :inner, :testval)
+    @test OpenAPI.Clients.haspropertyat(teststruct, "inner", "testval")
+    @test OpenAPI.Clients.haspropertyat(teststruct, :inner)
+    @test OpenAPI.Clients.getpropertyat(teststruct, :inner, :testval) == "test"
+end
+
+
 struct InvalidModel <: OpenAPI.APIModel
     test::Any
 


### PR DESCRIPTION
- specialize hasproperty for APIModel to check for `nothing`
- update `haspropertyat` method to evaluate correctly
- add tests