### PR TITLE
handle datetimes with more than millisec precision

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>", "JuliaHub"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -1,19 +1,31 @@
 const DATETIME_FORMATS = [
     Dates.DateFormat("yyyy-mm-dd"),
+    Dates.DateFormat("yyyy-mm-ddz"),
     Dates.DateFormat("yyyy-mm-dd HH:MM:SS"),
     Dates.DateFormat("yyyy-mm-ddTHH:MM:SS"),
-    Dates.DateFormat("yyyy-mm-dd HH:MM:SSzzz"),
-    Dates.DateFormat("yyyy-mm-ddTHH:MM:SSzzz"),
+    Dates.DateFormat("yyyy-mm-dd HH:MM:SSz"),
+    Dates.DateFormat("yyyy-mm-ddTHH:MM:SSz"),
     Dates.DateFormat("yyyy-mm-dd HH:MM:SS.sss"),
     Dates.DateFormat("yyyy-mm-ddTHH:MM:SS.sss"),
-    Dates.DateFormat("yyyy-mm-dd HH:MM:SS.sssZ"),
-    Dates.DateFormat("yyyy-mm-ddTHH:MM:SS.sssZ"),
-    Dates.DateFormat("yyyy-mm-dd HH:MM:SS.ssszzz"),
-    Dates.DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz"),
+    Dates.DateFormat("yyyy-mm-dd HH:MM:SS.sssz"),
+    Dates.DateFormat("yyyy-mm-ddTHH:MM:SS.sssz"),
 ]
+
+const rxdatetime = r"([0-9]{4}-[0-9]{2}-[0-9]{2}[T\s][0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?)[0-9]*([+\-Z][:\.0-9]*)"
+function reduce_to_ms_precision(datetimestr::String)
+    matches = match(rxdatetime, datetimestr)
+    if matches === nothing
+        return datetimestr
+    elseif length(matches.captures) == 2
+        return matches.captures[1] * matches.captures[2]
+    else
+        return matches.captures[1]
+    end
+end
 
 str2zoneddatetime(bytes::Vector{UInt8}) = str2zoneddatetime(String(bytes))
 function str2zoneddatetime(str::String)
+    str = reduce_to_ms_precision(str)
     for fmt in DATETIME_FORMATS
         try
             return ZonedDateTime(str, fmt)
@@ -27,6 +39,7 @@ str2zoneddatetime(datetime::DateTime) = ZonedDateTime(datetime, localzone())
 
 str2datetime(bytes::Vector{UInt8}) = str2datetime(String(bytes))
 function str2datetime(str::String)
+    str = reduce_to_ms_precision(str)
     for fmt in DATETIME_FORMATS
         try
             return DateTime(str, fmt)

--- a/test/client/utilstests.jl
+++ b/test/client/utilstests.jl
@@ -21,6 +21,33 @@ function test_date()
     dt = OpenAPI.str2date(convert(Vector{UInt8}, codeunits(dt_string)))
     @test dt == OpenAPI.str2date(Date(dt_now))
     @test dt_string == string(dt)
+
+    dates = ["2017-11-14", "2020-01-01"]
+    timesep = [" ", "T"]
+    times = ["11:03:53", "11:03:53.123", "11:03:53.123456", "11:03:53.123456789"]
+    timezones = ["", "+10:00", "-10:00", "Z"]
+
+    for date in dates
+        d = OpenAPI.str2date(date)
+        for sep in timesep
+            for time in times
+                t = (length(time) > 12) ? Time(SubString(time, 1, 12)) : Time(time)
+                for tz in timezones
+                    dt_string = date * sep * time * tz
+                    zdt = OpenAPI.str2zoneddatetime(convert(Vector{UInt8}, codeunits(dt_string)))
+                    dt = OpenAPI.str2datetime(convert(Vector{UInt8}, codeunits(dt_string)))
+                    @test d == Date(zdt)
+                    @test d == Date(dt)
+                    @test t == Time(zdt)
+                    @test t == Time(dt)
+                end
+            end
+        end
+    end
+
+    for tz in timezones
+        @test OpenAPI.str2date("2017-11-14"*tz) == Date(2017, 11, 14)
+    end
 end
 
 function as_taskfailedexception(ex)


### PR DESCRIPTION
OpenAPI spec seems to [suggest](https://swagger.io/docs/specification/data-models/data-types/) that the format should be [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6). But we do encounter APIs that send out date-time data with millisecond or nanosecond precision date-time.

The default date time packages in Julia (TimeZones.jl & Dates) do not support parsing sub-millisecond formats. It seems okay (since the specifications mention only rfc3339) to discard some of the precision while parsing such strings.So until there is a good way to handle it, in this PR we change the date-time parsing to discard some precision and not error out with such data. Also added more date-time related tests.