### PR TITLE
update tests

### DIFF
--- a/test/client/petstore_v3/petstore_test_userapi.jl
+++ b/test/client/petstore_v3/petstore_test_userapi.jl
@@ -12,6 +12,7 @@ import OpenAPI.Clients: Client, Ctx, ApiException, DEFAULT_TIMEOUT_SECS, with_ti
 const TEST_USER = "jloac"
 const TEST_USER1 = "jloac1"
 const TEST_USER2 = "jloac2"
+const TEST_USER3 = "jl oac 3"
 const PRESET_TEST_USER = "user1"    # this is the username that works for get user requests (as documented in the test docker container API)
 
 function test_404(uri)
@@ -170,6 +171,21 @@ function test(uri)
     logout_result, http_resp = logout_user(api)
     @test http_resp.status == 200
     @test logout_result === nothing
+
+    @info("UserApi - Test with spaces in username")
+    user3 = User(; id=300, username=TEST_USER3, firstName="test3", lastName="user3", email="jloac3@example.com", password="testpass3", phone="1000000003", userStatus=0)
+    create_result, http_resp = create_user(api, user3)
+    @test http_resp.status == 200
+    @test create_result === nothing
+
+    user3.firstName = "test3 updated"
+    api_return, http_resp = update_user(api, TEST_USER3, user3)
+    @test http_resp.status == 200
+    @test api_return === nothing
+
+    api_return, http_resp = delete_user(api, TEST_USER3)
+    @test http_resp.status == 200
+    @test api_return === nothing
 
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,12 @@ include("client/allany/runtests.jl")
             end
             servers_running && OpenAPIClientTests.runtests()
         finally
+            if run_tests_with_servers && !servers_running
+                # we probably had an error starting the servers
+                v2_out_str = isnothing(v2_out) ? "" : String(take!(v2_out))
+                v3_out_str = isnothing(v3_out) ? "" : String(take!(v3_out))
+                @warn("Servers not running", v2_ret=v2_ret, v2_out_str, v3_ret=v3_ret, v3_out_str)
+            end
             if run_tests_with_servers
                 stop_server(8080, v2_ret, v2_out)
                 stop_server(8081, v3_ret, v3_out)
@@ -56,6 +62,11 @@ include("client/allany/runtests.jl")
                 servers_running = false
             end
         finally
+            if run_tests_with_servers && !servers_running
+                # we probably had an error starting the servers
+                out_str = isnothing(out) ? "" : String(take!(out))
+                @warn("Servers not running", ret=ret, out_str)
+            end
             run_tests_with_servers && stop_server(8081, ret, out)
         end
     end
@@ -75,6 +86,11 @@ include("client/allany/runtests.jl")
                 servers_running = false
             end
         finally
+            if run_tests_with_servers && !servers_running
+                # we probably had an error starting the servers
+                out_str = isnothing(out) ? "" : String(take!(out))
+                @warn("Servers not running", ret=ret, out_str)
+            end
             run_tests_with_servers && stop_server(8081, ret, out)
         end
     end


### PR DESCRIPTION
Update tests for #28.
Add some diagnostic messages to troubleshoot CI.

Using `--pkgimages=no` for Julia 1.9, because otherwise we seem to be running into errors like:

```
Warning: The call to compilecache failed to create a usable precompiled cache file for OpenSSL_jll [458c3c95-2e84-50aa-8efc-19380b2a3a95]\n│   exception = Required dependency Preferences [21216c6a-2e73-6563-6e65-726566657250] failed to load from a cach" ⋯ 2762 bytes ⋯ "ding.jl:1613 [inlined]\n [7] macro expansion\n   @ ./lock.jl:267 [inlined]\n [8] require(into::Module, mod::Symbol)\n   @ Base ./loading.jl:1576\nin expression starting at /home/runner/work/OpenAPI.jl/OpenAPI.jl/test/server/petstore_v3/petstore_server.jl:1\n"
```