### PR TITLE
run a subset of tests for openapi-generator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["JuliaHub Inc."]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/client/runtests.jl
+++ b/test/client/runtests.jl
@@ -8,7 +8,7 @@ include("utilstests.jl")
 include("petstore_v3/runtests.jl")
 include("petstore_v2/runtests.jl")
 
-function runtests()
+function runtests(; skip_petstore=false)
     @testset "Client" begin
         @testset "Utils" begin
             test_longpoll_exception_check()
@@ -20,18 +20,20 @@ function runtests()
         @testset "Validations" begin
             test_validations()
         end
-        @testset "Petstore" begin
-            if get(ENV, "RUNNER_OS", "") == "Linux"
-                @testset "V3" begin
-                    @info("Running petstore v3 tests")
-                    PetStoreV3Tests.runtests()
+        if !skip_petstore
+            @testset "Petstore" begin
+                if get(ENV, "RUNNER_OS", "") == "Linux"
+                    @testset "V3" begin
+                        @info("Running petstore v3 tests")
+                        PetStoreV3Tests.runtests()
+                    end
+                    @testset "V2" begin
+                    @info("Running petstore v2 tests")
+                    PetStoreV2Tests.runtests()
+                    end
+                else
+                    @info("Skipping petstore tests in non Linux environment (can not run petstore docker on OSX or Windows)")
                 end
-                @testset "V2" begin
-                @info("Running petstore v2 tests")
-                PetStoreV2Tests.runtests()
-                end
-            else
-                @info("Skipping petstore tests in non Linux environment (can not run petstore docker on OSX or Windows)")
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,20 +11,20 @@ include("client/allany/runtests.jl")
     end
     @testset "Client" begin
         try
-            if run_tests_with_servers
+            if run_tests_with_servers && !openapi_generator_env
                 run(`client/petstore_v2/start_petstore_server.sh`)
                 run(`client/petstore_v3/start_petstore_server.sh`)
                 sleep(20) # let servers start
             end
-            OpenAPIClientTests.runtests()
+            OpenAPIClientTests.runtests(; skip_petstore=openapi_generator_env)
         finally
-            if run_tests_with_servers
+            if run_tests_with_servers && !openapi_generator_env
                 run(`client/petstore_v2/stop_petstore_server.sh`)
                 run(`client/petstore_v3/stop_petstore_server.sh`)
             end
         end
     end
-    run_tests_with_servers && sleep(20) # avoid port conflicts
+    run_tests_with_servers && !openapi_generator_env && sleep(20) # avoid port conflicts
     @testset "Server" begin
         v2_ret = v2_out = v3_ret = v3_out = nothing
         servers_running = true

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -8,6 +8,9 @@ const startup_flag = `--startup-file=no`
 # can run servers only on linux for now
 const run_tests_with_servers = get(ENV, "RUNNER_OS", "") == "Linux"
 
+# can only run a subset of tests when running on openapi-generator repo
+const openapi_generator_env = get(ENV, "OPENAPI_GENERATOR", "false") == "true"
+
 function run_server(script, flags=``)
     use_pkgimages = VERSION >= v"1.9" ? `--pkgimages=no` : ``
     srvrcmd = `$(joinpath(Sys.BINDIR, "julia")) $use_pkgimages $startup_flag $cov_flag $inline_flag $script $flags`


### PR DESCRIPTION
The openapi-generator repo will invoke OpenAPI.jl tests in near future. This PR is to enable only suitable tests to be run in that environment