### PR TITLE
add tests for plain default string values

### DIFF
--- a/test/modelgen/ModelGenClient/docs/TestModel.md
+++ b/test/modelgen/ModelGenClient/docs/TestModel.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **default_date** | **Date** |  | [optional] [default to OpenAPI.str2date("2011-11-11")]
 **default_datetime** | **ZonedDateTime** |  | [optional] [default to OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z")]
 **max_val** | **Int64** |  | [optional] [default to 100]
+**message** | **String** |  | [optional] [default to "success"]
+**name** | **String** |  | [default to "new"]
 **compute** | [***ComputeType**](ComputeType.md) |  | [optional] [default to nothing]
 
 

--- a/test/modelgen/ModelGenClient/src/models/model_TestModel.jl
+++ b/test/modelgen/ModelGenClient/src/models/model_TestModel.jl
@@ -9,6 +9,8 @@
         default_date=OpenAPI.str2date("2011-11-11"),
         default_datetime=OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z"),
         max_val=100,
+        message="success",
+        name="new",
         compute=nothing,
     )
 
@@ -16,6 +18,8 @@
     - default_date::Date
     - default_datetime::ZonedDateTime
     - max_val::Int64
+    - message::String
+    - name::String
     - compute::ComputeType
 """
 Base.@kwdef mutable struct TestModel <: OpenAPI.APIModel
@@ -23,22 +27,27 @@ Base.@kwdef mutable struct TestModel <: OpenAPI.APIModel
     default_date::Union{Nothing, Date} = OpenAPI.str2date("2011-11-11")
     default_datetime::Union{Nothing, ZonedDateTime} = OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z")
     max_val::Union{Nothing, Int64} = 100
+    message::Union{Nothing, String} = "success"
+    name::Union{Nothing, String} = "new"
     compute = nothing # spec type: Union{ Nothing, ComputeType }
 
-    function TestModel(limited_by, default_date, default_datetime, max_val, compute, )
+    function TestModel(limited_by, default_date, default_datetime, max_val, message, name, compute, )
         OpenAPI.validate_property(TestModel, Symbol("limited_by"), limited_by)
         OpenAPI.validate_property(TestModel, Symbol("default_date"), default_date)
         OpenAPI.validate_property(TestModel, Symbol("default_datetime"), default_datetime)
         OpenAPI.validate_property(TestModel, Symbol("max_val"), max_val)
+        OpenAPI.validate_property(TestModel, Symbol("message"), message)
+        OpenAPI.validate_property(TestModel, Symbol("name"), name)
         OpenAPI.validate_property(TestModel, Symbol("compute"), compute)
-        return new(limited_by, default_date, default_datetime, max_val, compute, )
+        return new(limited_by, default_date, default_datetime, max_val, message, name, compute, )
     end
 end # type TestModel
 
-const _property_types_TestModel = Dict{Symbol,String}(Symbol("limited_by")=>"String", Symbol("default_date")=>"Date", Symbol("default_datetime")=>"ZonedDateTime", Symbol("max_val")=>"Int64", Symbol("compute")=>"ComputeType", )
+const _property_types_TestModel = Dict{Symbol,String}(Symbol("limited_by")=>"String", Symbol("default_date")=>"Date", Symbol("default_datetime")=>"ZonedDateTime", Symbol("max_val")=>"Int64", Symbol("message")=>"String", Symbol("name")=>"String", Symbol("compute")=>"ComputeType", )
 OpenAPI.property_type(::Type{ TestModel }, name::Symbol) = Union{Nothing,eval(Base.Meta.parse(_property_types_TestModel[name]))}
 
 function check_required(o::TestModel)
+    o.name === nothing && (return false)
     true
 end
 

--- a/test/modelgen/ModelGenServer/docs/TestModel.md
+++ b/test/modelgen/ModelGenServer/docs/TestModel.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **default_date** | **Date** |  | [optional] [default to OpenAPI.str2date("2011-11-11")]
 **default_datetime** | **ZonedDateTime** |  | [optional] [default to OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z")]
 **max_val** | **Int64** |  | [optional] [default to 100]
+**message** | **String** |  | [optional] [default to "success"]
+**name** | **String** |  | [default to "new"]
 **compute** | [***ComputeType**](ComputeType.md) |  | [optional] [default to nothing]
 
 

--- a/test/modelgen/ModelGenServer/src/models/model_TestModel.jl
+++ b/test/modelgen/ModelGenServer/src/models/model_TestModel.jl
@@ -9,6 +9,8 @@
         default_date=OpenAPI.str2date("2011-11-11"),
         default_datetime=OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z"),
         max_val=100,
+        message="success",
+        name="new",
         compute=nothing,
     )
 
@@ -16,6 +18,8 @@
     - default_date::Date
     - default_datetime::ZonedDateTime
     - max_val::Int64
+    - message::String
+    - name::String
     - compute::ComputeType
 """
 Base.@kwdef mutable struct TestModel <: OpenAPI.APIModel
@@ -23,22 +27,27 @@ Base.@kwdef mutable struct TestModel <: OpenAPI.APIModel
     default_date::Union{Nothing, Date} = OpenAPI.str2date("2011-11-11")
     default_datetime::Union{Nothing, ZonedDateTime} = OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z")
     max_val::Union{Nothing, Int64} = 100
+    message::Union{Nothing, String} = "success"
+    name::Union{Nothing, String} = "new"
     compute = nothing # spec type: Union{ Nothing, ComputeType }
 
-    function TestModel(limited_by, default_date, default_datetime, max_val, compute, )
+    function TestModel(limited_by, default_date, default_datetime, max_val, message, name, compute, )
         OpenAPI.validate_property(TestModel, Symbol("limited_by"), limited_by)
         OpenAPI.validate_property(TestModel, Symbol("default_date"), default_date)
         OpenAPI.validate_property(TestModel, Symbol("default_datetime"), default_datetime)
         OpenAPI.validate_property(TestModel, Symbol("max_val"), max_val)
+        OpenAPI.validate_property(TestModel, Symbol("message"), message)
+        OpenAPI.validate_property(TestModel, Symbol("name"), name)
         OpenAPI.validate_property(TestModel, Symbol("compute"), compute)
-        return new(limited_by, default_date, default_datetime, max_val, compute, )
+        return new(limited_by, default_date, default_datetime, max_val, message, name, compute, )
     end
 end # type TestModel
 
-const _property_types_TestModel = Dict{Symbol,String}(Symbol("limited_by")=>"String", Symbol("default_date")=>"Date", Symbol("default_datetime")=>"ZonedDateTime", Symbol("max_val")=>"Int64", Symbol("compute")=>"ComputeType", )
+const _property_types_TestModel = Dict{Symbol,String}(Symbol("limited_by")=>"String", Symbol("default_date")=>"Date", Symbol("default_datetime")=>"ZonedDateTime", Symbol("max_val")=>"Int64", Symbol("message")=>"String", Symbol("name")=>"String", Symbol("compute")=>"ComputeType", )
 OpenAPI.property_type(::Type{ TestModel }, name::Symbol) = Union{Nothing,eval(Base.Meta.parse(_property_types_TestModel[name]))}
 
 function check_required(o::TestModel)
+    o.name === nothing && (return false)
     true
 end
 

--- a/test/modelgen/testmodelgen.jl
+++ b/test/modelgen/testmodelgen.jl
@@ -11,6 +11,8 @@ module TestModelGen
         @test testmodel.default_datetime == OpenAPI.str2zoneddatetime("2011-11-11T11:11:11Z")
         @test testmodel.max_val == 100
         @test testmodel.compute in ["cpu", "gpu"]
+        @test testmodel.message == "success"
+        @test testmodel.name == "new"
     end
 
     function runtests()

--- a/test/specs/modelgen.json
+++ b/test/specs/modelgen.json
@@ -52,10 +52,21 @@
                         "default": 100,
                         "enum": [100, 200, 300]
                     },
+                    "message": {
+                        "type": "string",
+                        "default": "success"
+                    },
+                    "name": {
+                        "type": "string",
+                        "default": "new"
+                    },
                     "compute": {
                         "$ref": "#/components/schemas/ComputeType"
                     }
-                }
+                },
+                "required": [
+                    "name"
+                ]
             },
             "ComputeType": {
                 "type": "string",


### PR DESCRIPTION
Adding tests for correct model generation when the default value for a member is set to a plain string value.