### PR TITLE
Fix incorrect response header content-type reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ JSON = "0.20, 0.21"
 LibCURL = "0.6"
 MbedTLS = "0.6.8, 0.7, 1"
 TimeZones = "1"
-URIs = "1.4"
+URIs = "1.3"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ JSON = "0.20, 0.21"
 LibCURL = "0.6"
 MbedTLS = "0.6.8, 0.7, 1"
 TimeZones = "1"
-URIs = "1.3"
+URIs = "1.4"
 julia = "1.6"
 
 [extras]

--- a/src/client.jl
+++ b/src/client.jl
@@ -312,7 +312,7 @@ end
 
 function header(resp::Downloads.Response, name::AbstractString, defaultval::AbstractString)
     for (n,v) in resp.headers
-        (n == name) && (return v)
+        (lowercase(n) == lowercase(name)) && (return v)
     end
     return defaultval
 end
@@ -321,7 +321,7 @@ response(::Type{Nothing}, resp::Downloads.Response, body) = nothing::Nothing
 response(::Type{T}, resp::Downloads.Response, body) where {T <: Real} = response(T, body)::T
 response(::Type{T}, resp::Downloads.Response, body) where {T <: String} = response(T, body)::T
 function response(::Type{T}, resp::Downloads.Response, body) where {T}
-    ctype = header(resp, "content-type", "application/json")
+    ctype = header(resp, "Content-Type", "application/json")
     response(T, is_json_mime(ctype), body)::T
 end
 response(::Type{T}, ::Nothing, body) where {T} = response(T, true, body)

--- a/src/client.jl
+++ b/src/client.jl
@@ -321,7 +321,7 @@ response(::Type{Nothing}, resp::Downloads.Response, body) = nothing::Nothing
 response(::Type{T}, resp::Downloads.Response, body) where {T <: Real} = response(T, body)::T
 response(::Type{T}, resp::Downloads.Response, body) where {T <: String} = response(T, body)::T
 function response(::Type{T}, resp::Downloads.Response, body) where {T}
-    ctype = header(resp, "Content-Type", "application/json")
+    ctype = header(resp, "content-type", "application/json")
     response(T, is_json_mime(ctype), body)::T
 end
 response(::Type{T}, ::Nothing, body) where {T} = response(T, true, body)


### PR DESCRIPTION
Related issue #46 
This bug is caused by incorrect response header content-type reading.

The response header `resp` use "content-type" not "Content-Type" as the key to store MIME. So the `header(resp, "Content-Type", "application/json")` always return default value `"application/json"`. That's why all the response content-type will be judged as `json`

![image](https://github.com/JuliaComputing/OpenAPI.jl/assets/17470335/0bbff6db-6c88-436e-af64-06828ddd6f22)

I don't add any test, cause no file download API in test specs.