### PR TITLE
handle Any types that can hold vectors also

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["JuliaHub Inc."]
-version = "0.1.19"
+version = "0.1.20"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/json.jl
+++ b/src/json.jl
@@ -89,6 +89,12 @@ end
 function from_json(o::T, name::Symbol, v::Vector) where {T <: APIModel}
     # in Julia we can not support JSON null unless the element type is explicitly set to support it
     ftype = property_type(T, name)
+
+    if ftype === Any
+        setfield!(o, name, v)
+        return o
+    end
+
     vtype = isa(ftype, Union) ? ((ftype.a === Nothing) ? ftype.b : ftype.a) : (ftype <: Vector) ? ftype : Union{}
     veltype = eltype(vtype)
     (Nothing <: veltype) || filter!(x->x!==nothing, v)


### PR DESCRIPTION
handle case where a property is declared as `object` but response contains a vector.