### PR TITLE
feat: use native interrupt support in Downloads.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["JuliaHub Inc."]
-version = "0.1.25"
+version = "0.1.26"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Detect if we are using a newer version of Download.jl that supports interrupting of requests natively and use that instead of throwing `InterruptException`.

ref: https://github.com/JuliaLang/Downloads.jl/pull/256 and https://github.com/JuliaLang/Downloads.jl/pull/259

fixes: #81