### PR TITLE
chore: re-enable julia nightly in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         version:
           - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
CI with nightlies were disabled earlier because of instabilities. It will be good to enable CI with julia nightlies back again, since https://github.com/JuliaComputing/OpenAPI.jl/pull/82 needs Downloads.jl version that's included only in the nightlies at the moment.