### PR TITLE
Handle binary response as `octet-stream`

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -162,6 +162,8 @@ end
 
 server_response(resp::HTTP.Response) = resp
 server_response(::Nothing) = server_response("")
+server_response(ret::Vector{UInt8}) =
+    HTTP.Response(200, ["Content-Type" => "application/octet-stream"], body=ret)
 server_response(ret) =
     server_response(to_json(ret), [Pair("Content-Type", "application/json")])
 server_response(resp::AbstractString, headers=HTTP.Headers()) =


### PR DESCRIPTION
Hi, thanks for the nice package, it works very well!

Here I want to make some small changes to smoothen the user experience of handling file upload/download.
Specifically, there are some changes to the `openapi-generator`, see
https://github.com/OpenAPITools/openapi-generator/pull/20355

Here is an example to reproduce the issue, and demonstrating the benefit of the PRs,
https://github.com/qiaojunfeng/test-julia-OpenAPI

Thanks again for creating this package!