### PR TITLE
Abort :http streaming read when the consumer closes the channel

### DIFF
--- a/src/client/httplibs/juliaweb_http.jl
+++ b/src/client/httplibs/juliaweb_http.jl
@@ -290,10 +290,16 @@ function _http_streaming_request(ctx, method, url, headers, body, timeout, bytes
         open_kwargs = merge(open_kwargs, (; verbose=get(ctx.client.clntoptions, :verbose, false)))
     end
 
+    # Capture the streaming connection so the abort-on-close watcher below can
+    # unblock the read task when the consumer closes `stream_to`. (Mirrors the
+    # `:downloads` backend, which interrupts its download task on channel close.)
+    io_ref = Ref{Any}(nothing)
+
     @sync begin
-        @async begin
+        read_task = @async begin
             try
                 HTTP.open(method, url, headers; open_kwargs...) do io
+                    io_ref[] = io
                     write(io, body)
                     captured_response[] = http_response = startread(io)
                     try
@@ -311,7 +317,15 @@ function _http_streaming_request(ctx, method, url, headers, body, timeout, bytes
                 end
             catch ex
                 close(output)
-                rethrow(ex)
+                # When the consumer closes `stream_to`, the watcher task below aborts
+                # this read (close(io) + a scheduled InterruptException); that surfaces
+                # here as an IO error or InterruptException. Swallow it so the streaming
+                # request returns normally instead of propagating a spurious error. A
+                # read timeout or genuine network error arrives while `stream_to` is
+                # still open (and is not our InterruptException), so it still throws.
+                if isopen(stream_to) && !isa(ex, InterruptException)
+                    rethrow(ex)
+                end
             end
         end
 
@@ -335,6 +349,45 @@ function _http_streaming_request(ctx, method, url, headers, body, timeout, bytes
                 end
             finally
                 close(stream_to)
+            end
+        end
+
+        @async begin
+            # Abort-on-close watcher: when the consumer closes `stream_to` (e.g. a
+            # k8s watch is stopped via `close(stream)`), abort the read task above so
+            # it unblocks immediately instead of hanging on the socket until the
+            # read-idle timeout. Mirrors the `:downloads` backend, which interrupts
+            # its download task on channel close.
+            try
+                while isopen(stream_to)
+                    wait(stream_to)
+                    yield()
+                end
+            catch ex
+                isa(ex, InvalidStateException) || rethrow(ex)
+            end
+            # Best-effort close of the connection. On HTTP/2 this alone does NOT wake a
+            # body read parked on the flow-control timer, so we also forcibly interrupt
+            # the read task (as `:downloads` does for non-interruptible downloads).
+            io = io_ref[]
+            # `io` may be `nothing` if the consumer closed before the connection was
+            # established; in practice a consumer only stops after receiving an event
+            # (or a timer fires seconds later), so the connection is already up. This
+            # is the same theoretical hole the `:downloads` watcher has.
+            if io !== nothing
+                try
+                    close(io)
+                catch
+                    # already closed / natural EOF — nothing to abort
+                end
+            end
+            # `stream_to` also closes on natural EOF (the chunk reader closes it after
+            # the read task finishes); the `istaskdone` guard skips the interrupt in
+            # that case. For JuliaRun's watch consumers an interrupt of an already-
+            # finishing read is harmless anyway — it maps to `is_request_interrupted`,
+            # the same signal a read-idle timeout produces, which they already retry on.
+            if !istaskdone(read_task)
+                schedule(read_task, InterruptException(); error=true)
             end
         end
     end


### PR DESCRIPTION
## Problem

The `:http` (HTTP.jl) streaming backend cannot abort an in-flight socket read when the consumer closes the event channel (`stream_to`).

`_http_streaming_request` runs two tasks under `@sync`: one reads the socket into a buffer stream, the other turns chunks into objects and `put!`s them onto `stream_to`. Closing `stream_to` ends the chunk-reader task, but nothing touches the connection `io` — so the read task stays blocked in `eof(io)`/`readbytes!(io)` until the read-idle timeout.

As a result, a streaming request whose consumer stops early **hangs** instead of returning. This is the normal control flow for a Kubernetes watch: the consumer reads events until the awaited one arrives (or a timer fires), then calls `close(stream)` to stop — and then the whole call blocks up to the read-idle timeout (e.g. 10 min) rather than returning in a couple of seconds.

The `:downloads` backend does not have this problem: it already has a third watcher task that interrupts the download when `stream_to` closes. The `:http` backend was missing the equivalent.

## Fix

Add an abort-on-close watcher task to `_http_streaming_request`, mirroring `:downloads`:

- Capture the connection `io` into a `Ref` when the request opens.
- A watcher waits on `stream_to`; when it closes, it `close(io)` **and** `schedule(read_task, InterruptException())`.
- The read task swallows the abort (channel closed, or our `InterruptException`) and returns normally. A genuine network error or read-idle timeout arrives while `stream_to` is still open, so it still propagates unchanged.

**Why the `InterruptException` and not just `close(io)`:** on HTTP/2, closing the stream does **not** wake a body read parked on the flow-control timer (`_wait_h2_body_progress!` → `timedwait`); the read stays blocked. Scheduling an `InterruptException` on the read task reliably unblocks it — the same fallback `:downloads` uses for non-interruptible downloads. `close(io)` is kept as a best-effort first step (and is sufficient on HTTP/1.1).

The interrupt surfaces to callers as `InvocationException("request was interrupted")` via `exec` (the existing `resp === nothing` path), which `is_request_interrupted` already recognizes — so consumers that already catch `is_request_interrupted` / `is_longpoll_timeout` need no changes.

## Scope

Shared `:http` code path — affects **both HTTP.jl 1.x and 2.x**. No public API change; non-streaming requests and normal streaming delivery are untouched.

## Validation

Reproduced the original hang and verified the fix against a **live Kubernetes watch** (Kuber.jl → OpenAPI) on both **HTTP 1.11.0** and **HTTP 2.5.1**, Julia 1.12:

- Watch that detects its condition and calls `close(stream)`: returns in **~2–3s** (previously hung to the read-idle timeout).
- Watch with a timeout timer that closes the stream: returns/errors at the **caller's** timeout (15s), not the read-idle timeout.
- Long-lived watch stopped by an external flag closing the stream: stops within the poll granularity.

All three previously hung. The genuine read-idle-timeout path (fires while `stream_to` is still open) still throws as before, so existing reconnect/retry logic is preserved.

## Note

A patch release would be needed to consume this downstream (e.g. in Kuber.jl-based watch code). Left the version bump to maintainers.