### PR TITLE
fix(client): abort-on-close watcher busy-spins while events are pending

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["JuliaHub Inc."]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/client/httplibs/juliaweb_http.jl
+++ b/src/client/httplibs/juliaweb_http.jl
@@ -373,9 +373,14 @@ function _http_streaming_request(ctx, method, url, headers, body, timeout, bytes
             # read-idle timeout. Mirrors the `:downloads` backend, which interrupts
             # its download task on channel close.
             try
+                # Block until the consumer closes the channel. Do NOT use
+                # `wait(stream_to)`: it returns as soon as data is AVAILABLE, so
+                # while an event sits in the channel not yet consumed, a
+                # wait+yield loop degenerates into a hot spin that burns a full
+                # core in scheduler/syscall overhead. Poll `isopen` instead;
+                # 250ms of extra abort latency is irrelevant here.
                 while isopen(stream_to)
-                    wait(stream_to)
-                    yield()
+                    sleep(0.25)
                 end
             catch ex
                 isa(ex, InvalidStateException) || rethrow(ex)


### PR DESCRIPTION
**Repurposed** — the original `readbytes!`→`readavailable` change is dropped: on a real `HTTP.Stream`, `readbytes!` returns per-chunk (verified empirically), so the original premise was wrong.

## Problem

The abort-on-close watcher introduced in #98:

```julia
while isopen(stream_to)
    wait(stream_to)
    yield()
end
```

`wait(::Channel)` returns as soon as data is **available**, not when the channel closes. So whenever an event has been `put!` but not yet consumed — e.g. the consumer is busy converting the previous event — this loop spins hot. Measured live on a k8s watch stream: 100% of a core in system time (`wchan=0`, running thread, 400 stime ticks per 4s) for as long as any event sat in the buffered channel.

## Fix

Poll `isopen` with a 250ms sleep. The watcher exists only to abort the blocked read when the consumer closes the channel; 250ms of extra abort latency is irrelevant, and the loop now costs nothing while idle.

Found while diagnosing deaf k8s watches in JuliaHub's JobLoops (root cause was in Kuber.jl — see JuliaComputing/Kuber.jl#67 — but this spin was compounding it by starving the same thread pool).

Bumps to 0.2.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)