### PR TITLE
deepObject: bracket-indexed arrays and nested objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenAPI", "REST"]
 license = "MIT"
 desc = "OpenAPI server and client helper for Julia"
 authors = ["JuliaHub Inc."]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/boundary.md
+++ b/docs/src/boundary.md
@@ -25,7 +25,7 @@ streams response bodies that are described by normal schemas.
 
 `strict=true` is the default. Use `strict=false` only for documented ecosystem
 compatibility cases. Permissive mode can retain ambiguous path templates, a
-non-object `deepObject` parameter, and operation security naming schemes the
+scalar `deepObject` parameter, and operation security naming schemes the
 document never declares (see [Security](security.md)), each with warnings. For
 OAS 3.0 documents, it also supports the common non-standard `nullable: true`
 plus `$ref` or `allOf` idiom. Strict mode follows the normative rule that

--- a/docs/src/clients.md
+++ b/docs/src/clients.md
@@ -85,7 +85,9 @@ Generated clients support:
 
 - path, query, header, and cookie parameters;
 - `simple`, `label`, `matrix`, `form`, `spaceDelimited`, `pipeDelimited`, and
-  `deepObject` serialization where the specification permits each style;
+  `deepObject` serialization where the specification permits each style,
+  plus the bracket-path `deepObject` extension for arrays and nested values
+  (see [deepObject bracket paths](@ref));
 - `allowReserved`, `allowEmptyValue`, explode defaults, and parameter `content`;
 - JSON and structured-suffix JSON media types;
 - text and binary bodies;

--- a/docs/src/servers.md
+++ b/docs/src/servers.md
@@ -121,6 +121,30 @@ the selected JSON schema accepts null. A full `HTTP.Response` bypasses
 generated status, header, and body validation. The handler owns that
 validation.
 
+### deepObject bracket paths
+
+OAS 3.x defines `deepObject` only for objects whose property values are
+scalars (`filter[role]=admin`). OpenAPI.jl extends the style with the bracket
+convention that `qs`, Rack, and PHP produce, so `deepObject` parameters may
+declare array schemas and nested object or array values. Nested objects nest
+brackets, arrays use zero-based bracket indices, and servers also accept
+`name[]=value` for appended items:
+
+```text
+filters[0][field]=severity&filters[0][values][0]=error&filters[0][values][1]=warning
+sorts[0]=-created_at&sorts[1]=%2Bname
+```
+
+Generated clients emit this form and generated servers decode it, in both
+strict and permissive mode. Bracket keys may arrive percent-encoded. The
+server rebuilds the value in the shape the parameter schema declares: integer
+keys become array indices only where the schema expects an array, so an
+`additionalProperties` object keeps `"0"` as a string key, and leaf values
+stay strings where the schema says `string` rather than being read as numbers.
+Schemas reached through `$ref`, `allOf`, `oneOf`, and `anyOf` are followed.
+The result is then validated against the schema as for every other parameter.
+Only scalar `deepObject` schemas remain a permissive-mode compatibility case.
+
 An operation that documents no success response at all (only error entries)
 produces a `missing_success_response` planning warning; its handler's
 `nothing` return is answered with an empty `200`, which the OpenAPI

--- a/src/planning.jl
+++ b/src/planning.jl
@@ -1549,14 +1549,16 @@ function _check_generation_support!(context::PlanningContext, strict::Bool)
             array_schema = "array" in types ||
                            _keyword_owner(view, "items") !== nothing ||
                            _keyword_owner(view, "prefixItems") !== nothing
-            if parameter.style === :deepObject && !_is_object_schema(view)
+            # Object and array schemas serialize with bracket paths (the
+            # documented deepObject extension); scalars have no bracket form.
+            if parameter.style === :deepObject && !_is_object_schema(view) && !array_schema
                 emit = strict ? _error! : _warning!
                 emit(
                     context.bag,
                     :invalid_deep_object_schema,
                     strict ?
-                    "deepObject serialization requires an object schema" :
-                    "non-object deepObject schema uses non-standard bracket compatibility serialization",
+                    "deepObject serialization requires an object or array schema" :
+                    "scalar deepObject schema uses non-standard plain serialization",
                     SourceLocation(
                         parameter.provenance.node.resource,
                         parameter.provenance.node.pointer,

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -253,6 +253,234 @@ end
 _schema_valid(spec::Spec, descriptor, value; direction::Symbol = :neutral) =
     isempty(_schema_issues(spec, descriptor, value; direction))
 
+# ── deepObject bracket paths ─────────────────────────────────────────────────
+# OAS 3.x defines `deepObject` only for objects whose property values are
+# scalars. OpenAPI.jl extends the style with the bracket convention shared by
+# qs, Rack, and PHP: nested objects nest brackets (`name[a][b]=v`), arrays use
+# zero-based bracket indices (`name[0][field]=v`), and decoders also accept
+# `name[]=v` for appended array items. Generated clients and servers use these
+# helpers so both sides agree on the wire format.
+
+# Flatten an encoded (JSON-shaped) value into `(wire_name, scalar)` pairs.
+function _deep_object_pairs!(output, name::String, encoded)
+    if encoded isa AbstractDict
+        for (key, item) in encoded
+            _deep_object_pairs!(output, string(name, '[', key, ']'), item)
+        end
+    elseif encoded isa AbstractVector || encoded isa Tuple
+        for (index, item) in enumerate(encoded)
+            _deep_object_pairs!(output, string(name, '[', index - 1, ']'), item)
+        end
+    else
+        push!(output, (name, encoded))
+    end
+    return output
+end
+
+_deep_object_pairs(name, encoded) =
+    _deep_object_pairs!(Tuple{String,Any}[], String(name), encoded)
+
+# Split a wire key into its bracket path below `name`: `name` gives an empty
+# path, `name[a][0][]` gives `["a", "0", ""]`. Returns `nothing` for keys that
+# belong to another parameter or are not well-formed bracket paths.
+function _deep_object_path(key::AbstractString, name::AbstractString)
+    key == name && return String[]
+    startswith(key, name) || return nothing
+    rest = SubString(key, nextind(key, lastindex(name)))
+    path = String[]
+    position = firstindex(rest)
+    while position <= lastindex(rest)
+        rest[position] == '[' || return nothing
+        close = findnext(']', rest, position)
+        close === nothing && return nothing
+        push!(path, String(SubString(rest, nextind(rest, position), prevind(rest, close))))
+        position = nextind(rest, close)
+    end
+    return path
+end
+
+# A decoded wire value whose JSON type the parameter schema decides later.
+struct _DeepObjectLeaf
+    text::String
+end
+
+# Insert `leaf` at `path` below `root`, creating intermediate objects. Array
+# items arrive as integer keys (or empty keys, which append), and stay objects
+# until `_deep_object_coerce` consults the schema.
+function _deep_object_assign!(root, path::Vector{String}, leaf)
+    isempty(path) && return leaf
+    object = root isa JSON.Object{String,Any} ? root : JSON.Object{String,Any}()
+    current = object
+    for (depth, token) in enumerate(path)
+        key = isempty(token) ? string(length(current)) : token
+        if depth == length(path)
+            current[key] = leaf
+        else
+            child = get(current, key, nothing)
+            if !(child isa JSON.Object{String,Any})
+                child = JSON.Object{String,Any}()
+                current[key] = child
+            end
+            current = child
+        end
+    end
+    return object
+end
+
+function _deep_object_types(data)
+    data isa AbstractDict || return String[]
+    type = get(data, "type", nothing)
+    type isa AbstractString && return [String(type)]
+    type isa AbstractVector && return String[String(item) for item in type if item isa AbstractString]
+    return String[]
+end
+
+function _deep_object_expects_array(data)
+    data isa AbstractDict || return false
+    types = _deep_object_types(data)
+    "object" in types && return false
+    "array" in types && return true
+    isempty(types) || return false
+    (haskey(data, "items") || haskey(data, "prefixItems")) || return false
+    return !any(
+        haskey(data, key) for key in ("properties", "additionalProperties", "patternProperties")
+    )
+end
+
+function _deep_object_indices(value::AbstractDict)
+    isempty(value) && return nothing
+    indices = Tuple{Int,Any}[]
+    for (key, item) in value
+        index = tryparse(Int, key)
+        (index === nothing || index < 0) && return nothing
+        push!(indices, (index, item))
+    end
+    sort!(indices; by = first)
+    return Any[item for (_, item) in indices]
+end
+
+function _deep_object_leaf(data, leaf::_DeepObjectLeaf)
+    types = _deep_object_types(data)
+    if "string" in types && all(type -> type == "string" || type == "null", types)
+        return leaf.text
+    end
+    return _header_atom(leaf.text)
+end
+
+function _deep_object_child(schema, tokens...)
+    schema === nothing && return nothing
+    pointer = schema.root.pointer
+    for token in tokens
+        pointer = pointer / String(token)
+    end
+    return SchemaEngine.trysubschema(
+        schema,
+        SchemaEngine.Resources.NodeId(schema.root.resource, pointer),
+    )
+end
+
+function _deep_object_reference(schema, reference)
+    target = SchemaEngine.reference_target(schema, schema.root, "\$ref")
+    if target === nothing
+        target = try
+            SchemaEngine.Resources.resolve(
+                schema.registry,
+                SchemaEngine.Resources.Reference(schema.root.resource, reference),
+            ).id
+        catch
+            nothing
+        end
+    end
+    target === nothing && return nothing
+    return SchemaEngine.trysubschema(schema, target)
+end
+
+# Rebuild a bracket tree in the JSON shape `schema` describes: integer-keyed
+# objects become arrays where the schema expects an array, leaves become typed
+# atoms unless the schema declares them strings, and nested schemas are
+# followed through `\$ref`, `allOf`, `oneOf`, and `anyOf`. Without a schema the
+# tree keeps its object shape and leaves become atoms.
+function _deep_object_coerce(spec::Spec, descriptor, value)
+    schema = _schema_at(spec, descriptor, :input)
+    return _deep_object_coerce(schema, value, 0)
+end
+
+function _deep_object_coerce(schema, value, depth::Int)
+    depth > 64 && return _deep_object_coerce(nothing, value, 0)
+    data = schema === nothing ? nothing : schema.data
+    if data isa AbstractDict
+        reference = get(data, "\$ref", nothing)
+        if reference isa AbstractString
+            resolved = _deep_object_reference(schema, reference)
+            if resolved !== nothing
+                value = _deep_object_coerce(resolved, value, depth + 1)
+                schema.dialect.ref_siblings || return value
+            end
+        end
+        alternatives = get(data, "allOf", nothing)
+        if alternatives isa AbstractVector
+            for index in eachindex(alternatives)
+                child = _deep_object_child(schema, "allOf", string(index - 1))
+                child === nothing && continue
+                value = _deep_object_coerce(child, value, depth + 1)
+            end
+        end
+        for keyword in ("oneOf", "anyOf")
+            alternatives = get(data, keyword, nothing)
+            alternatives isa AbstractVector || continue
+            for index in eachindex(alternatives)
+                child = _deep_object_child(schema, keyword, string(index - 1))
+                child === nothing && continue
+                candidate = _deep_object_coerce(child, value, depth + 1)
+                if SchemaEngine.validate(child, candidate) === nothing
+                    value = candidate
+                    break
+                end
+            end
+        end
+    end
+    value isa _DeepObjectLeaf && return _deep_object_leaf(data, value)
+    if value isa AbstractDict
+        items = _deep_object_expects_array(data) ? _deep_object_indices(value) : nothing
+        if items === nothing
+            properties = data isa AbstractDict ? get(data, "properties", nothing) : nothing
+            additional = data isa AbstractDict ? get(data, "additionalProperties", nothing) : nothing
+            output = JSON.Object{String,Any}()
+            for (key, item) in value
+                child = properties isa AbstractDict && haskey(properties, key) ?
+                        _deep_object_child(schema, "properties", key) : nothing
+                if child === nothing && additional isa AbstractDict
+                    child = _deep_object_child(schema, "additionalProperties")
+                end
+                output[key] = _deep_object_coerce(child, item, depth + 1)
+            end
+            return output
+        end
+        value = items
+    end
+    if value isa AbstractVector
+        items = data isa AbstractDict ? get(data, "items", nothing) : nothing
+        prefix = data isa AbstractDict ? get(data, "prefixItems", nothing) : nothing
+        modern = schema !== nothing && schema.dialect.modern_items
+        output = Vector{Any}(undef, length(value))
+        for (index, item) in enumerate(value)
+            child = nothing
+            if modern && prefix isa AbstractVector && index <= length(prefix)
+                child = _deep_object_child(schema, "prefixItems", string(index - 1))
+            elseif items isa AbstractVector && !modern
+                child = index <= length(items) ?
+                        _deep_object_child(schema, "items", string(index - 1)) :
+                        _deep_object_child(schema, "additionalItems")
+            elseif items isa AbstractDict
+                child = _deep_object_child(schema, "items")
+            end
+            output[index] = _deep_object_coerce(child, item, depth + 1)
+        end
+        return output
+    end
+    return value
+end
+
 struct Upload
     data::Vector{UInt8}
     filename::Union{Nothing,String}
@@ -1148,21 +1376,9 @@ function _query_parameter(
 )
     encoded = _encode(value)
     if style === :deepObject
-        if encoded isa AbstractDict
-            any(
-                item -> item isa AbstractDict || item isa AbstractVector || item isa Tuple,
-                values(encoded),
-            ) && throw(ArgumentError("deepObject does not define nested object or array values"))
-            return Tuple{String,String,Bool}[
-                (string(name, '[', key, ']'), _scalar(item), false) for
-                (key, item) in _pairs(encoded)
-            ]
-        elseif encoded isa AbstractVector || encoded isa Tuple
-            return Tuple{String,String,Bool}[
-                (string(name, "[]"), _scalar(item), false) for item in encoded
-            ]
-        end
-        return [(name, _scalar(encoded), false)]
+        return Tuple{String,String,Bool}[
+            (key, _scalar(item), false) for (key, item) in _deep_object_pairs(name, encoded)
+        ]
     elseif style in (:spaceDelimited, :pipeDelimited)
         explode && throw(ArgumentError("$style with explode=true is undefined"))
         delimiter = style === :spaceDelimited ? " " : "|"
@@ -1808,9 +2024,8 @@ end
 function _multipart_style_pairs(name, value, style, explode)
     encoded = _encode(value)
     if style === :deepObject
-        encoded isa AbstractDict || throw(ArgumentError("deepObject requires an object"))
         return Pair{String,Any}[
-            string(name, '[', key, ']') => item for (key, item) in _pairs(encoded)
+            key => item for (key, item) in _deep_object_pairs(name, encoded)
         ]
     elseif style in (:spaceDelimited, :pipeDelimited)
         explode && throw(ArgumentError("$style with explode=true is undefined"))

--- a/src/schema_engine/compiled.jl
+++ b/src/schema_engine/compiled.jl
@@ -1466,6 +1466,16 @@ function subschema(
     return subschema(schemas, Resources.NodeId(resource, pointer))
 end
 
+"""
+Return a compiled view of a schema node, or `nothing` when the location was
+not compiled as a schema.
+"""
+function trysubschema(template::CompiledSchema, requested::Resources.NodeId)
+    canonical = Resources.canonical(template.registry, requested)
+    haskey(getfield(template, :evaluation_nodes), canonical) || return nothing
+    return subschema(template, requested)
+end
+
 function CompiledSchema(
     resource::Resources.Resource,
     pointer::Resources.JSONPointer = Resources.JSONPointer();

--- a/src/servergen.jl
+++ b/src/servergen.jl
@@ -9,8 +9,9 @@ const GENERATED_SERVER_IMPORTS = raw"""
 const SchemaEngine = OpenAPI.SchemaEngine
 import OpenAPI.Runtime:
     ABSENT, Absent, DecodeError, MultipartPartHeaders, SchemaValidationError,
-    UnsupportedMediaType, Upload,
+    UnsupportedMediaType, Upload, _DeepObjectLeaf,
     _base_media_type, _decode, _decode_schema_header, _decode_sequential_json,
+    _deep_object_assign!, _deep_object_coerce, _deep_object_path,
     _encode, _encode_sequential_json, _form_fields, _header_atom, _header_scalar,
     _header_type_variant, _header_values, _is_json_media, _is_sequential_json_media,
     _media_type, _object, _parse_json, _required, _safe_header, _schema_valid,
@@ -288,34 +289,24 @@ function _decode_query_parameter(descriptor, pairs, consumed)
     end
     style = descriptor.style
     if style === :deepObject
-        object = JSON.Object{String,Any}()
-        items = Any[]
-        scalar = nothing
+        # Bracket paths (`name[a][0][field]=v`, `name[]=v`) build a tree of
+        # objects whose JSON shape the parameter schema settles afterwards.
+        value = nothing
         found = false
-        prefix = name * "["
-        list_key = name * "[]"
         for (index, pair) in enumerate(pairs)
-            key = pair.first
-            value() = _percent_decode(String(pair.second); plus_space = true)
-            if key == list_key
-                push!(items, _header_atom(value()))
-            elseif startswith(key, prefix) && endswith(key, ']')
-                start = nextind(key, lastindex(prefix))
-                stop = prevind(key, lastindex(key))
-                start <= stop || continue
-                inner = String(SubString(key, start, stop))
-                object[inner] = _header_atom(value())
-            elseif key == name
-                scalar = _header_atom(value())
-            else
-                continue
-            end
+            path = _deep_object_path(pair.first, name)
+            path === nothing && continue
+            leaf = _DeepObjectLeaf(_percent_decode(String(pair.second); plus_space = true))
+            value = _deep_object_assign!(value, path, leaf)
             consumed[index] = true
             found = true
         end
         found || return ABSENT
-        value = !isempty(object) ? object : (!isempty(items) ? items : scalar)
-        return _finish_parameter(descriptor, value, context)
+        return _finish_parameter(
+            descriptor,
+            _deep_object_coerce(_SPEC, descriptor.schema, value),
+            context,
+        )
     elseif style === :spaceDelimited || style === :pipeDelimited
         index = _first_pair_index(pairs, name)
         index === nothing && return ABSENT

--- a/test/runtime.jl
+++ b/test/runtime.jl
@@ -335,19 +335,49 @@
             true,
             false,
         ) == [
-            ("expand[]", "customer", false),
-            ("expand[]", "invoice", false),
+            ("expand[0]", "customer", false),
+            ("expand[1]", "invoice", false),
         ]
         @test invoke(:_query_parameter, "created", 7, :deepObject, true, false) ==
               [("created", "7", false)]
-        @test_throws ArgumentError invoke(
+        @test invoke(
             :_query_parameter,
             "filter",
             Dict("nested" => Dict("x" => 1)),
             :deepObject,
             true,
             false,
-        )
+        ) == [("filter[nested][x]", "1", false)]
+        @test invoke(
+            :_query_parameter,
+            "filters",
+            [(; field = "severity", values = ["error", "warning"])],
+            :deepObject,
+            true,
+            false,
+        ) == [
+            ("filters[0][field]", "severity", false),
+            ("filters[0][values][0]", "error", false),
+            ("filters[0][values][1]", "warning", false),
+        ]
+
+        # Server-side bracket path parsing and tree building.
+        @test invoke(:_deep_object_path, "filters", "filters") == String[]
+        @test invoke(:_deep_object_path, "filters[0][values][]", "filters") ==
+              ["0", "values", ""]
+        @test invoke(:_deep_object_path, "filters[é]", "filters") == ["é"]
+        @test invoke(:_deep_object_path, "filtersx", "filters") === nothing
+        @test invoke(:_deep_object_path, "filters[0", "filters") === nothing
+        @test invoke(:_deep_object_path, "filters[0]x", "filters") === nothing
+        @test invoke(:_deep_object_path, "other[0]", "filters") === nothing
+        Leaf = OpenAPI.Runtime._DeepObjectLeaf
+        tree = invoke(:_deep_object_assign!, nothing, ["0", "field"], Leaf("a"))
+        tree = invoke(:_deep_object_assign!, tree, ["0", "values", ""], Leaf("x"))
+        tree = invoke(:_deep_object_assign!, tree, ["0", "values", ""], Leaf("y"))
+        @test tree["0"]["field"] == Leaf("a")
+        @test collect(keys(tree["0"]["values"])) == ["0", "1"]
+        @test tree["0"]["values"]["1"] == Leaf("y")
+        @test invoke(:_deep_object_assign!, nothing, String[], Leaf("s")) == Leaf("s")
 
         @test invoke(:_header_parameter, ["a", "b"], false) == "a,b"
         malformed_header = (

--- a/test/semantics.jl
+++ b/test/semantics.jl
@@ -335,8 +335,8 @@ end
         @test ignored.severity === :warning
     end
 
-    @testset "permissive vendor serialization compatibility" begin
-        document = minimal_openapi(
+    @testset "deepObject accepts arrays; scalars are vendor compatibility" begin
+        deep_document(schema) = minimal_openapi(
             "3.0.4",
             OpenAPI.obj(
                 "/items" => OpenAPI.obj(
@@ -348,18 +348,28 @@ end
                                 "in" => "query",
                                 "style" => "deepObject",
                                 "explode" => true,
-                                "schema" => OpenAPI.obj(
-                                    "type" => "array",
-                                    "items" => OpenAPI.obj("type" => "string"),
-                                ),
+                                "schema" => schema,
                             ),
                         ],
                     ),
                 ),
             ),
         )
-        @test_throws OpenAPI.OpenAPIError OpenAPI.plan(document)
-        plan = OpenAPI.plan(document; strict = false)
+        # Arrays (and nested objects) use the documented bracket-path extension
+        # and plan at strict without diagnostics.
+        array_document = deep_document(
+            OpenAPI.obj("type" => "array", "items" => OpenAPI.obj("type" => "string")),
+        )
+        plan = OpenAPI.plan(array_document)
+        @test !any(
+            diagnostic -> diagnostic.code === :invalid_deep_object_schema,
+            plan.diagnostics,
+        )
+        @test OpenAPI.serverplan(array_document) isa OpenAPI.ServerPlan
+        # Scalars have no bracket form: strict rejects, permissive warns.
+        scalar_document = deep_document(OpenAPI.obj("type" => "string"))
+        @test_throws OpenAPI.OpenAPIError OpenAPI.plan(scalar_document)
+        plan = OpenAPI.plan(scalar_document; strict = false)
         warning = only(
             diagnostic for diagnostic in plan.diagnostics if
             diagnostic.code === :invalid_deep_object_schema

--- a/test/servergen.jl
+++ b/test/servergen.jl
@@ -902,3 +902,230 @@ end
         @test OpenAPI.plan(document) isa OpenAPI.ClientPlan
     end
 end
+
+@testset "deepObject bracket paths" begin
+    string_schema() = OpenAPI.obj("type" => "string")
+    string_array() = OpenAPI.obj("type" => "array", "items" => string_schema())
+    component(name) = OpenAPI.obj("\$ref" => "#/components/schemas/$name")
+    deep(name, schema) = OpenAPI.obj(
+        "name" => name,
+        "in" => "query",
+        "style" => "deepObject",
+        "explode" => true,
+        "schema" => schema,
+    )
+    document = OpenAPI.obj(
+        "openapi" => "3.0.3",
+        "info" => OpenAPI.obj("title" => "Listing", "version" => "1.0.0"),
+        "paths" => OpenAPI.obj(
+            "/items" => OpenAPI.obj(
+                "get" => OpenAPI.obj(
+                    "operationId" => "listItems",
+                    "parameters" => Any[
+                        deep(
+                            "filters",
+                            OpenAPI.obj("type" => "array", "items" => component("Filter")),
+                        ),
+                        deep("sorts", string_array()),
+                        deep("page", component("Page")),
+                        deep("labels", component("Labels")),
+                    ],
+                    "responses" => OpenAPI.obj(
+                        "200" => OpenAPI.obj(
+                            "description" => "echo",
+                            "content" => OpenAPI.obj(
+                                "application/json" => OpenAPI.obj("schema" => component("Echo")),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        "components" => OpenAPI.obj(
+            "schemas" => OpenAPI.obj(
+                "Filter" => OpenAPI.obj(
+                    "type" => "object",
+                    "properties" => OpenAPI.obj(
+                        "field" => string_schema(),
+                        "op" => string_schema(),
+                        "values" => string_array(),
+                        "limit" => OpenAPI.obj("type" => "integer"),
+                    ),
+                ),
+                "Page" => OpenAPI.obj(
+                    "type" => "object",
+                    "properties" => OpenAPI.obj(
+                        "size" => OpenAPI.obj("type" => "integer"),
+                        "tags" => string_array(),
+                    ),
+                ),
+                "Labels" => OpenAPI.obj(
+                    "type" => "object",
+                    "additionalProperties" => string_schema(),
+                ),
+                "Echo" => OpenAPI.obj(
+                    "type" => "object",
+                    "properties" => OpenAPI.obj(
+                        "filters" => OpenAPI.obj("type" => "array", "items" => component("Filter")),
+                        "sorts" => string_array(),
+                        "page" => component("Page"),
+                        "labels" => component("Labels"),
+                    ),
+                ),
+            ),
+        ),
+    )
+    # Array and nested deepObject schemas plan at strict (the default).
+    @test OpenAPI.serverplan(document) isa OpenAPI.ServerPlan
+    @test OpenAPI.plan(document) isa OpenAPI.ClientPlan
+
+    server_host = Module(:DeepBracketServerHost)
+    Base.include_string(
+        server_host,
+        OpenAPI.server(document; name = "DeepBracketServer"),
+        "DeepBracketServer.jl",
+    )
+    S = Base.invokelatest(getfield, server_host, :DeepBracketServer)
+    impl = Module(:DeepBracketImpl)
+    Base.include_string(
+        impl,
+        """
+        using OpenAPI
+        present(value) = !(value === nothing || value === OpenAPI.Runtime.ABSENT)
+        function listitems(request; filters = nothing, sorts = nothing, page = nothing, labels = nothing)
+            echo = Dict{String,Any}()
+            present(filters) && (echo["filters"] = filters)
+            present(sorts) && (echo["sorts"] = sorts)
+            present(page) && (echo["page"] = page)
+            present(labels) && (echo["labels"] = labels)
+            return echo
+        end
+        """,
+        "DeepBracketImpl.jl",
+    )
+    router = HTTP.Router()
+    Base.invokelatest(getfield(S, :register!), router, impl)
+    server = HTTP.serve!(router, "127.0.0.1", 0; verbose = false)
+    try
+        base = "http://127.0.0.1:$(HTTP.port(server))"
+        fetch_items(query) = HTTP.get("$base/items?$query"; status_exception = false)
+        parsed(response) = JSON.parse(String(response.body))
+
+        client_host = Module(:DeepBracketClientHost)
+        Base.include_string(
+            client_host,
+            OpenAPI.client(document; name = "DeepBracketClient"),
+            "DeepBracketClient.jl",
+        )
+        C = Base.invokelatest(getfield, client_host, :DeepBracketClient)
+        call(name, args...; kwargs...) =
+            Base.invokelatest(getfield(C, name), args...; kwargs...)
+        call(:server!, base)
+
+        @testset "client encodes nested values as indexed bracket paths" begin
+            filter = call(:FilterModel; field = "severity", values = ["error", "warning"])
+            @test Base.invokelatest(
+                OpenAPI.Runtime._query_parameter,
+                "filters",
+                [filter],
+                :deepObject,
+                true,
+                false,
+            ) == [
+                ("filters[0][field]", "severity", false),
+                ("filters[0][values][0]", "error", false),
+                ("filters[0][values][1]", "warning", false),
+            ]
+        end
+
+        @testset "typed client to server round trip" begin
+            echo = call(
+                :listitems;
+                filters = [
+                    call(
+                        :FilterModel;
+                        field = "severity",
+                        op = "in",
+                        values = ["error", "warning"],
+                        limit = 5,
+                    ),
+                ],
+                sorts = ["-created_at", "+name"],
+                page = call(:Page; size = 20, tags = ["a", "b"]),
+                labels = call(
+                    :Labels;
+                    additional_properties = Dict("env" => "prod", "0" => "zero"),
+                ),
+            )
+            @test length(echo.filters) == 1
+            @test echo.filters[1].field == "severity"
+            @test echo.filters[1].op == "in"
+            @test echo.filters[1].values == ["error", "warning"]
+            @test echo.filters[1].limit == 5
+            @test echo.sorts == ["-created_at", "+name"]
+            @test echo.page.size == 20
+            @test echo.page.tags == ["a", "b"]
+            @test echo.labels.additional_properties == Dict("env" => "prod", "0" => "zero")
+        end
+
+        @testset "bracket-index wire format (qs default)" begin
+            response = fetch_items(
+                "filters[0][field]=severity&filters[0][op]=in&filters[0][values][0]=error" *
+                "&filters[0][values][1]=warning&filters[0][limit]=5" *
+                "&sorts[0]=-created_at&sorts[1]=%2Bname",
+            )
+            @test response.status == 200
+            echo = parsed(response)
+            @test echo["filters"] == [
+                Dict(
+                    "field" => "severity",
+                    "op" => "in",
+                    "values" => ["error", "warning"],
+                    "limit" => 5,
+                ),
+            ]
+            @test echo["sorts"] == ["-created_at", "+name"]
+        end
+
+        @testset "appended items, encoded brackets, sparse indices" begin
+            response = fetch_items("sorts[]=a&sorts[]=b")
+            @test response.status == 200
+            @test parsed(response)["sorts"] == ["a", "b"]
+
+            response = fetch_items("sorts%5B0%5D=2024&filters%5B0%5D%5Bfield%5D=f")
+            @test response.status == 200
+            echo = parsed(response)
+            @test echo["sorts"] == ["2024"] # string schema keeps digits as text
+            @test echo["filters"] == [Dict("field" => "f")]
+
+            response = fetch_items("sorts[10]=late&sorts[2]=early")
+            @test response.status == 200
+            @test parsed(response)["sorts"] == ["early", "late"]
+        end
+
+        @testset "schema decides between array index and object key" begin
+            response = fetch_items(
+                "labels[0]=zero&labels[env]=prod&page[size]=20&page[tags][0]=a&page[tags][1]=b",
+            )
+            @test response.status == 200
+            echo = parsed(response)
+            @test echo["labels"] == Dict("0" => "zero", "env" => "prod")
+            @test echo["page"] == Dict("size" => 20, "tags" => ["a", "b"])
+        end
+
+        @testset "shapes the schema rejects produce 400" begin
+            response = fetch_items("sorts=plain")
+            @test response.status == 400
+            @test occursin("sorts", String(response.body))
+
+            response = fetch_items("filters[0][values]=notarray")
+            @test response.status == 400
+            @test occursin("filters", String(response.body))
+
+            @test fetch_items("filters[0][limit]=many").status == 400
+            @test fetch_items("page[size]=abc").status == 400
+        end
+    finally
+        close(server)
+    end
+end


### PR DESCRIPTION
Fixes #110.

## Summary

`deepObject` query parameters with array schemas or nested object/array values worked in 0.2 (added in #78) but not in 1.0.0: strict rejected the schema, permissive planned it and then failed every request, and the client encoder threw on nested values. This restores end-to-end support using the bracket convention that `qs`, Rack and PHP produce, as a documented extension accepted at strict.

```text
filters[0][field]=severity&filters[0][values][0]=error&filters[0][values][1]=warning
sorts[0]=-created_at&sorts[1]=%2Bname
```

## Changes

- **Planning** (`src/planning.jl`): array schemas under `deepObject` plan at strict without diagnostics. Only scalar schemas still emit `invalid_deep_object_schema` (error at strict, warning at permissive).
- **Client encoder** (`src/runtime.jl`): nested dicts and vectors flatten recursively into indexed bracket paths. Arrays now encode as `name[0]=…` rather than `name[]=…`, matching the 0.2 encoder and the `qs` default. The multipart deepObject encoder shares the helper.
- **Server decoder** (`src/servergen.jl` + `src/runtime.jl`): full bracket paths (including percent-encoded brackets and `name[]` appends) build a tree, and a schema-guided pass rebuilds it in the declared shape before validation. Integer keys become array indices only where the schema expects an array, so an `additionalProperties` object keeps `"0"` as a string key. Leaves stay text where the schema says `string`, so `sorts[0]=2024` is no longer read as an integer. `$ref`, `allOf`, `oneOf` and `anyOf` are followed.
- **Schema engine**: adds a generic non-throwing `trysubschema` accessor.
- **Docs**: new "deepObject bracket paths" section in the servers manual, linked from the clients manual; the boundary page now lists only scalar `deepObject` as a permissive case.
- **Version**: 1.1.0, since strict mode accepts new input.

## Decisions worth a look

1. Arrays of scalars now encode indexed (`expand[0]=a&expand[1]=b`) instead of `expand[]=a&expand[]=b`. The server accepts both forms; this is a visible client wire change from 1.0.0.
2. Arrays are accepted at strict with no diagnostic. An informational note would be a one-line change in the planner if preferred.

## Verification

- The reproduction from #110 returns 200 with typed models in strict mode for both spec variants, and the client emits `filters[0][field]=…` pairs.
- Full suite on Julia 1.12.7 passes, including a new server-level testset covering the `qs` wire format, `[]` appends, encoded brackets, sparse indices, the array-vs-object-key decision, string leaves, and 400s for invalid shapes. Julia 1.10 was not available locally.
- `OPENAPI_CORPUS_TESTS=small` passes. Docs build passes and the new cross-reference resolves.
- The checked-in JuliaC `--trim=safe` workload still passes. Note that the request/response runtime paths (query encoding, JSON decode, schema validation) were not trim-safe before this change and are not made so here; a widened trim workload fails the same way before and after.
